### PR TITLE
Only print final status message once, add finish! method to fast-forward progress meter

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -2,7 +2,7 @@ module ProgressMeter
 
 using Compat
 
-export Progress, next!, cancel, @showprogress
+export Progress, next!, cancel, finish!, @showprogress
 
 type Progress
     n::Int
@@ -43,7 +43,7 @@ function next!(p::Progress)
     t = time()
     p.counter += 1
     if p.counter >= p.n
-        if p.printed
+        if p.counter == p.n && p.printed
             percentage_complete = 100.0 * p.counter / p.n
             bar = barstring(p.barlen, percentage_complete)
             dur = durationstring(t-p.tfirst)
@@ -81,6 +81,12 @@ function cancel(p::Progress, msg::String = "Aborted before all tasks were comple
         println()
     end
     return
+end
+
+function finish!(p::Progress)
+    while p.counter < p.n
+        next!(p)
+    end
 end
 
 function printover(io::IO, s::String, color::Symbol = :color_normal)

--- a/test/test.jl
+++ b/test/test.jl
@@ -120,5 +120,18 @@ println("Testing @showprogress macro on typed comprehension")
 testfunc9(100, 0.1, 0.01)
 
 
+function testfunc10(n, k, dt, tsleep)
+    p = ProgressMeter.Progress(n, dt)
+    for i = 1:k
+        sleep(tsleep)
+        ProgressMeter.next!(p)
+    end
+    ProgressMeter.finish!(p)
+end
+println("Testing under-shooting progress with finish!...")
+testfunc10(107, 105, 0.01, 0.01)
+println("Testing over-shooting progress with finish!...")
+testfunc10(107, 111, 0.01, 0.01)
+
 println("")
 println("All tests complete")


### PR DESCRIPTION
Thanks for this great package! 

In one of my projects, I know approximately how many iterations a while loop is going to take but I often over-shoot or under-shoot the actual value by a little bit. This patch makes the output of ProgressMeter look sane in either case: when over-shooting, it won't print out the final "Progress: 1XX%" line more than once. When under-shooting, you can now call `finish!` to fast-forward the progress meter to 100% at the end of the loop. The tests I added give examples of both applications.