### PR TITLE
WIP: unified constructor with keyword arguments

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3-
+julia 0.3
 Compat

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -1,3 +1,5 @@
+VERSION >= v"0.4.0-dev+6521" && __precompile__()
+
 module ProgressMeter
 
 using Compat


### PR DESCRIPTION
As I mentioned in #18, it would be worth unifying two inner constructors into an inner constructor using keyword arguments to make it easy to set some of the parameters and keeping backward compatibility; this is a working implementation of it.

But before finishing my job, let me ask a few questions.

1. Why the original two constructors specify different `dt` values (`1.0` vs. `0.01`)?
2. Again, why `barlen` is set to different values between the two constructors (`0` vs. tty width)?

If there is no reason to do so, I think setting a same value would be better.