### PR TITLE
Use appropriate control character within ESS

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -112,7 +112,7 @@ function finish!(p::Progress)
 end
 
 function printover(io::IO, s::AbstractString, color::Symbol = :color_normal)
-    if isdefined(Main, :IJulia)
+    if isdefined(Main, :IJulia) || isdefined(Main, :ESS)
         print(io, "\r" * s)
     else
         print(io, "\u1b[1G")   # go to first column


### PR DESCRIPTION
This lets `printover` work as intended within ESS.

Note that one case where it still doesn't work is running `Pkg.test("ProgressMeter")` within ESS. However `include("runtests.jl")` works fine.