### PR TITLE
Add docstrings and a progress meter based on a threshold

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.3
   - 0.4
   - nightly
 notifications:

--- a/README.md
+++ b/README.md
@@ -13,12 +13,26 @@ Pkg.add("ProgressMeter")
 
 ## Usage
 
+### Progress meters for tasks with a pre-determined number of steps
+
 This works for functions that process things in loops.
 Here's a demonstration of how to use it:
 
 ```julia
 using ProgressMeter
 
+@showprogress 1 "Computing..." for i in 1:50
+    sleep(0.1)
+end
+```
+
+This will use a minimum update interval of 1 second, and show the ETA and final duration.  If your computation runs so quickly that it never needs to show progress, no extraneous output will be displayed.
+
+The `@showprogress` macro wraps a `for` loop or comprehension, as long as the object being iterated over implements the `length` method.  This macro will correctly handle any `continue` statements in a `for` loop as well.
+
+You can also control progress updates and reports manually:
+
+```julia
 function my_long_running_function(filenames::Array)
     n = length(filenames)
     p = Progress(n, 1)   # minimum update interval: 1 second
@@ -29,10 +43,6 @@ function my_long_running_function(filenames::Array)
 end
 ```
 
-You should see a green status line that indicates progress during this computation, including ETA and final duration.
-
-If your computation runs so quickly that it never needs to show progress, no extraneous output will be displayed.
-
 For tasks such as reading file data where the progress increment varies between iterations, you can use `update!`:
 
 ```julia
@@ -40,22 +50,22 @@ using ProgressMeter
 
 function readFileLines(fileName::String)
     file = open(fileName,"r")
-    
+
     seekend(file)
     fileSize = position(file)
-    
+
     seekstart(file)
     p = Progress(fileSize, 1)   # minimum update interval: 1 second
     while !eof(file)
         line = readline(file)
         # Here's where you do all the hard, slow work
-        
+
         update!(p, position(file))
     end
 end
 ```
 
-Optionally, a description string can be specified which will be prepended to the output, and a progress meter `M` characters long can be shown.  E.g. 
+Optionally, a description string can be specified which will be prepended to the output, and a progress meter `M` characters long can be shown.  E.g.
 
 ```julia
 p = Progress(n, 1, "Computing initial pass...", 50)
@@ -69,15 +79,22 @@ Computing initial pass...53%|###########################                       |
 
 in a manner similar to [python-progressbar](https://code.google.com/p/python-progressbar/).
 
-Finally, it is possible to use the `@showprogress` macro to wrap a `for` loop or comprehension, as long as the object being iterated over implements the `length` method.  This macro will correctly handle any `continue` statements in a `for` loop as well.
+### Progress meters for tasks with an unknown number of steps
+
+Some tasks only terminate when some criterion is satisfied, for
+example to achieve convergence within a specified tolerance.  In such
+circumstances, you can use the `ProgressThresh` type:
 
 ```julia
-@showprogress 1 "Computing..." for i in 1:50
+prog = ProgressThresh(1e-5, "Minimizing:")
+for val in logspace(2, -6, 20)
+    ProgressMeter.update!(prog, val)
     sleep(0.1)
 end
 ```
 
+This will display progress until `val` drops below the threshold value (1e-5).
+
 ## Credits
 
 Thanks to Alan Bahm, Andrew Burroughs, and Jim Garrison for major enhancements to this package.
-

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.4
 Compat

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -4,7 +4,7 @@ module ProgressMeter
 
 using Compat
 
-export Progress, next!, update!, cancel, finish!, @showprogress
+export Progress, ProgressThresh, next!, update!, cancel, finish!, @showprogress
 
 """
 `ProgressMeter` contains a suite of utilities for displaying progress
@@ -12,21 +12,24 @@ in long-running computations. The major functions/types in this module
 are:
 
 - `@showprogress`: an easy interface for straightforward situations
-- `Progress`: an object for managing progress updates
+- `Progress`: an object for managing progress updates with a predictable number of iterations
+- `ProgressThresh`: an object for managing progress updates where termination is governed by a threshold
 - `next!` and `update!`: report that progress has been made
 - `cancel` and `finish!`: early termination
 """
 ProgressMeter
+
+abstract AbstractProgress
 
 """
 `prog = Progress(n; dt=0.1, desc="Progress: ", color=:green,
 output=STDOUT, barlen=tty_width(desc))` creates a progress meter for a
 task with `n` iterations or stages. Output will be generated at
 intervals at least `dt` seconds apart, and perhaps longer if each
-iteration takes longer than `dt`. `desc` is a description describing
+iteration takes longer than `dt`. `desc` is a description of
 the current task.
 """
-type Progress
+type Progress <: AbstractProgress
     n::Int
     dt::Float64
     counter::Int
@@ -57,6 +60,45 @@ Progress(n::Integer, dt::Real=0.1, desc::AbstractString="Progress: ",
 
 Progress(n::Integer, desc::AbstractString) = Progress(n, desc=desc)
 
+
+"""
+`prog = ProgressThresh(thresh; dt=0.1, desc="Progress: ",
+color=:green, output=STDOUT)` creates a progress meter for a task
+which will terminate once a value less than or equal to `thresh` is
+reached. Output will be generated at intervals at least `dt` seconds
+apart, and perhaps longer if each iteration takes longer than
+`dt`. `desc` is a description of the current task.
+"""
+type ProgressThresh{T<:Real} <: AbstractProgress
+    thresh::T
+    dt::Float64
+    val::T
+    counter::Int
+    triggered::Bool
+    tfirst::Float64
+    tlast::Float64
+    printed::Bool        # true if we have issued at least one status update
+    desc::AbstractString # prefix to the percentage, e.g.  "Computing..."
+    color::Symbol        # default to green
+    output::IO           # output stream into which the progress is written
+
+    function ProgressThresh(thresh;
+                            dt::Real=0.1,
+                            desc::AbstractString="Progress: ",
+                            color::Symbol=:green,
+                            output::IO=STDOUT)
+        tfirst = tlast = time()
+        printed = false
+        new(thresh, dt, typemax(T), 0, false, tfirst, tlast, printed, desc, color, output)
+    end
+end
+
+ProgressThresh(thresh::Real, dt::Real=0.1, desc::AbstractString="Progress: ",
+         color::Symbol=:green, output::IO=STDOUT) =
+    ProgressThresh{typeof(thresh)}(thresh, dt=dt, desc=desc, color=color, output=output)
+
+ProgressThresh(thresh::Real, desc::AbstractString) = ProgressThresh{typeof(thresh)}(thresh, desc=desc)
+
 #...length of percentage and ETA string with days is 29 characters
 tty_width(desc) = max(0, Base.tty_size()[2] - (length(desc) + 29))
 
@@ -84,13 +126,41 @@ function updateProgress!(p::Progress)
         eta = durationstring(eta_sec)
         msg = @sprintf "%s%3u%%%s  ETA: %s" p.desc round(Int, percentage_complete) bar eta
         printover(p.output, msg, p.color)
-        # Compensate for any overhead of printing. This can be especially important
-        # if you're running over a slow network connection.
+        # Compensate for any overhead of printing. This can be
+        # especially important if you're running over a slow network
+        # connection.
         p.tlast = t + 2*(time()-t)
         p.printed = true
     end
 end
 
+function updateProgress!(p::ProgressThresh)
+    t = time()
+    if p.val <= p.thresh && !p.triggered
+        p.triggered = true
+        if p.printed
+            p.triggered = true
+            dur = durationstring(t-p.tfirst)
+            msg = @sprintf "%s Time: %s (%d iterations)" p.desc dur p.counter
+            printover(p.output, msg, p.color)
+            println(p.output)
+        end
+        return
+    end
+
+    if t > p.tlast+p.dt && !p.triggered
+        elapsed_time = t - p.tfirst
+        msg = @sprintf "%s (thresh = %g, value = %g)" p.desc p.thresh p.val
+        printover(p.output, msg, p.color)
+        # Compensate for any overhead of printing. This can be
+        # especially important if you're running over a slow network
+        # connection.
+        p.tlast = t + 2*(time()-t)
+        p.printed = true
+    end
+end
+
+# update progress display
 """
 `next!(prog, [color])` reports that one unit of progress has been
 made. Depending on the time interval since the last update, this may
@@ -108,13 +178,14 @@ function next!(p::Progress, color::Symbol)
     next!(p)
 end
 
-
-
 """
 `update!(prog, counter, [color])` sets the progress counter to
 `counter`, relative to the `n` units of progress specified when `prog`
 was initialized.  Depending on the time interval since the last
 update, this may or may not result in a change to the display.
+
+If `prog` is a `ProgressThresh`, `update!(prog, val, [color])` specifies
+the current value.
 
 You may optionally change the color of the display. See also `next!`.
 """
@@ -128,6 +199,18 @@ function update!(p::Progress, counter::Int, color::Symbol)
     update!(p, counter)
 end
 
+function update!(p::ProgressThresh, val)
+    p.val = val
+    p.counter += 1
+    updateProgress!(p)
+end
+
+function update!(p::ProgressThresh, val, color::Symbol)
+    p.color = color
+    update!(p, val)
+end
+
+
 """
 `cancel(prog, [msg], [color=:red])` cancels the progress display
 before all tasks were completed. Optionally you can specify the
@@ -135,7 +218,7 @@ message printed and its color.
 
 See also `finish!`.
 """
-function cancel(p::Progress, msg::AbstractString = "Aborted before all tasks were completed", color = :red)
+function cancel(p::AbstractProgress, msg::AbstractString = "Aborted before all tasks were completed", color = :red)
     if p.printed
         printover(p.output, msg, color)
         println(p.output)
@@ -153,6 +236,11 @@ function finish!(p::Progress)
         next!(p)
     end
 end
+
+function finish!(p::ProgressThresh)
+    update!(p, p.thresh)
+end
+
 
 function printover(io::IO, s::AbstractString, color::Symbol = :color_normal)
     if isdefined(Main, :IJulia) || isdefined(Main, :ESS)

--- a/test/test.jl
+++ b/test/test.jl
@@ -229,5 +229,13 @@ end
 println("Testing keyword arguments")
 testfunc13()
 
+# Threshold-based progress reports
+println("Testing threshold-based progress")
+prog = ProgressMeter.ProgressThresh(1e-5, "Minimizing:")
+for val in logspace(2, -6, 20)
+    ProgressMeter.update!(prog, val)
+    sleep(0.1)
+end
+
 println("")
 println("All tests complete")


### PR DESCRIPTION
Some tasks, like minimizing a function, often take an indeterminate number of iterations: for example, one might iterate a L-BFGS step until the function value stops changing by more than `thresh`, and it's not predictable how many iterations this will take. This PR adds an alternative type of progress meter customized for such settings.

Example of output during the computation:
```
Computing nonnegative factorization: (thresh = 1e-07, value = 2.84137e-6)
```
Example of output once `value` drops below `thresh`:
```
Computing nonnegative factorization: Time: 0:00:09 (164 iterations)
```
