### PR TITLE
Shorten the ETA string when t >= 10 days.

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -335,8 +335,10 @@ function durationstring(nsec)
     seconds = r - 60*minutes
 
     hhmmss = @sprintf "%u:%02u:%02u" hours minutes seconds
-    if days>0
-       return @sprintf "%u days, %s" days hhmmss
+    if days>9
+        return @sprintf "%.2f days" nsec/(60*60*24)
+    elseif days>0
+        return @sprintf "%u days, %s" days hhmmss
     end
     hhmmss
 end


### PR DESCRIPTION
First of all I want to say I love this package. I use it all the time.

I have some computations where the first few iterations have some additional overhead that pushes the ETA over 10 days. In this case the progress meter over flows onto a second line (if you use `tty_width` as the bar length). This PR simply reduces the length of the ETA string in this case. As a result the ETA is less precise, but I don't think you are usually very interested in the number of seconds when your ETA is over 10 days anyway.

*Example output now:*
```
julia> using ProgressMeter

julia> N = 10000000
       p = Progress(N, "Progress: ")
       for idx = 1:N
           sleep(0.5)
           next!(p)
       end
Progress:   0%|                              |  ETA: 61.17 days
```