### PR TITLE
Fix hidden cursor after the progress with showvalues=

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -290,12 +290,13 @@ function printvalues!(p::AbstractProgress, showvalues; color = false)
         msg = "\n  " * rpad(string(name) * ": ", maxwidth+2+1) * string(value)
         (color == false) ? print(p.output, msg) : print_with_color(color, p.output, msg)
     end
-    print(p.output, "\u1b[?25l") # Hide cursor
     p.numprintedvalues = length(showvalues)
 end
 
 function move_cursor_up_while_clearing_lines(io, numlinesup)
-    [print(io, "\u1b[1G\u1b[K\u1b[A") for _ in 1:numlinesup]
+    for _ in 1:numlinesup
+        print(io, "\u1b[1G\u1b[K\u1b[A")
+    end
 end
 
 function printover(io::IO, s::AbstractString, color::Symbol = :color_normal)


### PR DESCRIPTION
The PR just removes the code that hides the cursor. An alternative would be to restore the cursor state after the progress is done, but it still would not handle `Ctrl+C` cases.