### PR TITLE
Remove `@showprogress` tests for dict comprehensions on julia 0.6

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -408,6 +408,7 @@ macro showprogress(args...)
     origloop = loop = copy(loop)
     metersym = gensym("meter")
 
+    # NOTE: dict_comprehension and typed_dict_comprehension are gone as of julia 0.6.
     if isa(loop, Expr) && loop.head === :for
         outerassignidx = 1
         loopbodyidx = endof(loop.args)

--- a/test/test.jl
+++ b/test/test.jl
@@ -183,9 +183,11 @@ function testfunc11a(n, dt, tsleep)
     @test s == [(y,z) => 2z for z in 1:n, y in 1:n]
 end
 
-println("Testing @showprogress macro on dict comprehension")
-testfunc11(100, 0.1, 0.1)
-testfunc11a(10, 0.1, 0.1)
+if VERSION < v"0.6.0-pre"
+    println("Testing @showprogress macro on dict comprehension")
+    testfunc11(100, 0.1, 0.1)
+    testfunc11a(10, 0.1, 0.1)
+end
 
 
 function testfunc12(n, dt, tsleep)
@@ -200,9 +202,11 @@ function testfunc12a(n, dt, tsleep)
     @test s == (Tuple{Int,Int}=>Int)[(y,z) => 2z for z in 1:n, y in 1:n]
 end
 
-println("Testing @showprogress macro on typed dict comprehension")
-testfunc12(100, 0.1, 0.1)
-testfunc12a(10, 0.1, 0.1)
+if VERSION < v"0.6.0-pre"
+    println("Testing @showprogress macro on typed dict comprehension")
+    testfunc12(100, 0.1, 0.1)
+    testfunc12a(10, 0.1, 0.1)
+end
 
 
 function testfunc13()


### PR DESCRIPTION
Dict comprehensions are gone in 0.6, replaced with a "generator" syntax. Since `@showprogress` does not support generators (yet), I've simply disabled these tests on julia 0.6.