### PR TITLE
Fix Julia 0.6 deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.7.12
+Compat 0.17

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -19,7 +19,7 @@ are:
 """
 ProgressMeter
 
-abstract AbstractProgress
+@compat abstract type AbstractProgress end
 
 
 
@@ -113,14 +113,14 @@ type ProgressThresh{T<:Real} <: AbstractProgress
     output::IO           # output stream into which the progress is written
     numprintedvalues::Int   # num values printed below progress in last iteration
 
-    function ProgressThresh(thresh;
+    @compat function (::Type{ProgressThresh{T}}){T}(thresh;
                             dt::Real=0.1,
                             desc::AbstractString="Progress: ",
                             color::Symbol=:green,
                             output::IO=STDOUT)
         tfirst = tlast = time()
         printed = false
-        new(thresh, dt, typemax(T), 0, false, tfirst, tlast, printed, desc, color, output, 0)
+        new{T}(thresh, dt, typemax(T), 0, false, tfirst, tlast, printed, desc, color, output, 0)
     end
 end
 


### PR DESCRIPTION
* abstract type declaration (requires Compat 0.17)
* inner constructor syntax

Note: Tests are still expected to fail on 0.6 pending #65.