### PR TITLE
Replace control char \u1b[A with \r.

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -293,7 +293,7 @@ end
 
 function move_cursor_up_while_clearing_lines(io, numlinesup)
     for _ in 1:numlinesup
-        print(io, "\u1b[1G\u1b[K\u1b[A")
+        print(io, "\r\u1b[K\u1b[A")
     end
 end
 
@@ -305,9 +305,9 @@ function printover(io::IO, s::AbstractString, color::Symbol = :color_normal)
         print_with_color(color, io, s) # Jupyter notebooks support ANSI color codes
         Main.IJulia.stdio_bytes[] = 0 # issue #76: circumvent IJulia I/O throttling
     else
-        print(io, "\u1b[1G")   # go to first column
+        print(io, "\r")         # go to first column
         print_with_color(color, io, s)
-        print(io, "\u1b[K")    # clear the rest of the line
+        print(io, "\u1b[K")     # clear the rest of the line
     end
 end
 


### PR DESCRIPTION
This fixes https://github.com/tpapp/julia-repl/issues/13 using the solution
already employed by `Base.Terminals`, see
https://github.com/JuliaLang/julia/commit/c9f28da19bfe061280fa91120c08ee851e1ff31e

I am not an expert on terminal control characters, but since it is used by Base
it must have seen a lot of testing so I assume it is correct. I tested on Linux,
using various terminals (also with tmux), and ansi-term inside Emacs, and
existing behavior is maintained.

(the neatest solution, of course, would be factoring out the control characters
in Base.Terminals in such a way that they could be sent to any `::IO`, this is but
a quick workaround).