### PR TITLE
Deprecation fixes for Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.51.0
+Compat 0.52.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.41.0
+Compat 0.51.0

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -2,6 +2,7 @@ __precompile__()
 
 module ProgressMeter
 
+using Compat: lastindex
 using Compat.Printf: @sprintf
 
 export Progress, ProgressThresh, BarGlyphs, next!, update!, cancel, finish!, @showprogress
@@ -414,12 +415,12 @@ macro showprogress(args...)
 
     if isa(loop, Expr) && loop.head === :for
         outerassignidx = 1
-        loopbodyidx = endof(loop.args)
+        loopbodyidx = lastindex(loop.args)
     elseif isa(loop, Expr) && loop.head === :comprehension
-        outerassignidx = endof(loop.args)
+        outerassignidx = lastindex(loop.args)
         loopbodyidx = 1
     elseif isa(loop, Expr) && loop.head === :typed_comprehension
-        outerassignidx = endof(loop.args)
+        outerassignidx = lastindex(loop.args)
         loopbodyidx = 2
     else
         throw(ArgumentError("Final argument to @showprogress must be a for loop or comprehension."))
@@ -430,7 +431,7 @@ macro showprogress(args...)
         @assert length(loop.args) == loopbodyidx
         loop = loop.args[outerassignidx] = copy(loop.args[outerassignidx])
         @assert loop.head === :generator
-        outerassignidx = endof(loop.args)
+        outerassignidx = lastindex(loop.args)
         loopbodyidx = 1
     end
 

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module ProgressMeter
 
-using Compat: lastindex
+using Compat: lastindex, printstyled
 using Compat.Printf: @sprintf
 
 export Progress, ProgressThresh, BarGlyphs, next!, update!, cancel, finish!, @showprogress
@@ -289,7 +289,7 @@ function printvalues!(p::AbstractProgress, showvalues; color = false)
     maxwidth = maximum(Int[length(string(name)) for (name, _) in showvalues])
     for (name, value) in showvalues
         msg = "\n  " * rpad(string(name) * ": ", maxwidth+2+1) * string(value)
-        (color == false) ? print(p.output, msg) : print_with_color(color, p.output, msg)
+        (color == false) ? print(p.output, msg) : printstyled(p.output, msg; color=color)
     end
     p.numprintedvalues = length(showvalues)
 end
@@ -305,11 +305,11 @@ function printover(io::IO, s::AbstractString, color::Symbol = :color_normal)
         print(io, '\r', s)
     elseif isdefined(Main, :IJulia)
         print(io, '\r')
-        print_with_color(color, io, s) # Jupyter notebooks support ANSI color codes
+        printstyled(io, s; color=color) # Jupyter notebooks support ANSI color codes
         Main.IJulia.stdio_bytes[] = 0 # issue #76: circumvent IJulia I/O throttling
     else
         print(io, "\r")         # go to first column
-        print_with_color(color, io, s)
+        printstyled(io, s; color=color)
         print(io, "\u1b[K")     # clear the rest of the line
     end
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -1,5 +1,6 @@
 import ProgressMeter
 using Compat.Test
+using Compat.Random
 
 srand(123)
 


### PR DESCRIPTION
This requires https://github.com/JuliaLang/Compat.jl/pull/481 which I have tentatively assumed to be included in a future Compat 0.52. (Tests will fail immediately due to Compat 0.52 not being available, yet).