### PR TITLE
Use `stderr` instead of `STDERR` on newer Julia

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.52.0
+Compat 0.55.0

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module ProgressMeter
 
-using Compat: lastindex, printstyled
+using Compat: stderr, lastindex, printstyled
 using Compat.Printf: @sprintf
 
 export Progress, ProgressThresh, BarGlyphs, next!, update!, cancel, finish!, @showprogress
@@ -51,7 +51,7 @@ end
 
 """
 `prog = Progress(n; dt=0.1, desc="Progress: ", color=:green,
-output=STDERR, barlen=tty_width(desc))` creates a progress meter for a
+output=stderr, barlen=tty_width(desc))` creates a progress meter for a
 task with `n` iterations or stages. Output will be generated at
 intervals at least `dt` seconds apart, and perhaps longer if each
 iteration takes longer than `dt`. `desc` is a description of
@@ -75,7 +75,7 @@ mutable struct Progress <: AbstractProgress
                       dt::Real=0.1,
                       desc::AbstractString="Progress: ",
                       color::Symbol=:green,
-                      output::IO=STDERR,
+                      output::IO=stderr,
                       barlen::Integer=tty_width(desc),
                       barglyphs::BarGlyphs=BarGlyphs('|','█','█',' ','|'))
         counter = 0
@@ -86,7 +86,7 @@ mutable struct Progress <: AbstractProgress
 end
 
 Progress(n::Integer, dt::Real, desc::AbstractString="Progress: ",
-         barlen::Integer=tty_width(desc), color::Symbol=:green, output::IO=STDERR) =
+         barlen::Integer=tty_width(desc), color::Symbol=:green, output::IO=stderr) =
     Progress(n, dt=dt, desc=desc, barlen=barlen, color=color, output=output)
 
 Progress(n::Integer, desc::AbstractString) = Progress(n, desc=desc)
@@ -94,7 +94,7 @@ Progress(n::Integer, desc::AbstractString) = Progress(n, desc=desc)
 
 """
 `prog = ProgressThresh(thresh; dt=0.1, desc="Progress: ",
-color=:green, output=STDERR)` creates a progress meter for a task
+color=:green, output=stderr)` creates a progress meter for a task
 which will terminate once a value less than or equal to `thresh` is
 reached. Output will be generated at intervals at least `dt` seconds
 apart, and perhaps longer if each iteration takes longer than
@@ -118,7 +118,7 @@ mutable struct ProgressThresh{T<:Real} <: AbstractProgress
                                dt::Real=0.1,
                                desc::AbstractString="Progress: ",
                                color::Symbol=:green,
-                               output::IO=STDERR) where T
+                               output::IO=stderr) where T
         tfirst = tlast = time()
         printed = false
         new{T}(thresh, dt, typemax(T), 0, false, tfirst, tlast, printed, desc, color, output, 0)
@@ -126,7 +126,7 @@ mutable struct ProgressThresh{T<:Real} <: AbstractProgress
 end
 
 ProgressThresh(thresh::Real, dt::Real=0.1, desc::AbstractString="Progress: ",
-         color::Symbol=:green, output::IO=STDERR) =
+         color::Symbol=:green, output::IO=stderr) =
     ProgressThresh{typeof(thresh)}(thresh, dt=dt, desc=desc, color=color, output=output)
 
 ProgressThresh(thresh::Real, desc::AbstractString) = ProgressThresh{typeof(thresh)}(thresh, desc=desc)

--- a/test/test.jl
+++ b/test/test.jl
@@ -1,9 +1,9 @@
 import ProgressMeter
 using Compat.Test
 using Compat.Random
+using Compat: stderr
 
 srand(123)
-
 
 function testfunc(n, dt, tsleep)
     p = ProgressMeter.Progress(n, dt)
@@ -187,7 +187,7 @@ function testfunc13()
         ProgressMeter.next!(p)
     end
     # full keyword argumetns
-    p = ProgressMeter.Progress(n, dt=0.01, desc="", color=:red, output=STDERR, barlen=40)
+    p = ProgressMeter.Progress(n, dt=0.01, desc="", color=:red, output=stderr, barlen=40)
     for i in 1:n
         sleep(0.1)
         ProgressMeter.next!(p)
@@ -213,7 +213,7 @@ function testfunc14(barglyphs)
         ProgressMeter.next!(p)
     end
     p = ProgressMeter.Progress(n, dt=0.01, desc="",
-                               color=:red, output=STDERR, barlen=40,
+                               color=:red, output=stderr, barlen=40,
                                barglyphs=ProgressMeter.BarGlyphs(barglyphs))
     for i in 1:n
         sleep(0.1)


### PR DESCRIPTION
Again, this depends on a not-yet-merged feature of Compat which I tentatively assume to be included in the next Compat version. (Tests pass locally when checking out the respective branch of Compat.)