### PR TITLE
Fix Jupyter issue

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -294,8 +294,12 @@ function printvalues!(p::AbstractProgress, showvalues; color = false)
 end
 
 function move_cursor_up_while_clearing_lines(io, numlinesup)
-    for _ in 1:numlinesup
-        print(io, "\r\u1b[K\u1b[A")
+    if isdefined(Main, :IJulia)
+        Main.IJulia.clear_output()
+    else
+        for _ in 1:numlinesup
+            print(io, "\r\u1b[K\u1b[A")
+        end
     end
 end
 

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -294,7 +294,7 @@ function printvalues!(p::AbstractProgress, showvalues; color = false)
 end
 
 function move_cursor_up_while_clearing_lines(io, numlinesup)
-    if isdefined(Main, :IJulia)
+    if isdefined(Main, :IJulia) && numlinesup > 0
         Main.IJulia.clear_output()
     else
         for _ in 1:numlinesup

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -287,20 +287,20 @@ function printvalues!(p::AbstractProgress, showvalues; color = false)
     length(showvalues) == 0 && return
     maxwidth = maximum(Int[length(string(name)) for (name, _) in showvalues])
     for (name, value) in showvalues
-        msg = "\n  " * rpad(string(name) * ": ", maxwidth+2+1) * string(value)
+        msg = "  |  " * string(name) * ": " * string(value)
         (color == false) ? print(p.output, msg) : print_with_color(color, p.output, msg)
     end
     p.numprintedvalues = length(showvalues)
 end
 
 function move_cursor_up_while_clearing_lines(io, numlinesup)
-    if isdefined(Main, :IJulia) && numlinesup > 0
-        Main.IJulia.clear_output()
-    else
+#    if isdefined(Main, :IJulia) && numlinesup > 0
+#        Main.IJulia.clear_output()
+#    else
         for _ in 1:numlinesup
             print(io, "\r\u1b[K\u1b[A")
         end
-    end
+#    end
 end
 
 function printover(io::IO, s::AbstractString, color::Symbol = :color_normal)


### PR DESCRIPTION
I've seen this in Jupyter.

```
Training...  1%|                                                  |  ETA: 0:01:39
  epoch:     5
Training...  2%|█                                                 |  ETA: 0:01:34
  epoch:     11
Training...  3%|██                                                |  ETA: 0:01:31
  epoch:     17
Training...  5%|██                                                |  ETA: 0:01:29
  epoch:     23
Training...  6%|███                                               |  ETA: 0:01:28
  epoch:     29
Training...  7%|████                                              |  ETA: 0:01:27
  epoch:     35
Training...  8%|████                                              |  ETA: 0:01:25
  epoch:     41
  neg_elbo:  195.79621860107238
```

I used IJulia's function to clear the output to solve this issue. There is blink when using the function but I think it's better than having things above.