### PR TITLE
RFC: Add Project.toml and set version to 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
 julia:
   - 0.7
   - 1.0
+  - 1.1
+  - 1.2
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ProgressMeter"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "v0.5.6"
+version = "v1.0.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,18 @@
 name = "ProgressMeter"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "v1.0.0"
+version = "1.0.0"
 
 [deps]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-julia = "0.7"
+julia = "0.7, 1"
+
+[extras]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Random", "Distributed"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,9 @@
+name = "ProgressMeter"
+uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
+version = "v0.5.6"
+
+[deps]
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[compat]
+julia = "0.7"


### PR DESCRIPTION
The downside at present is that releases require manually bumping the version here in addition to tagging/creating a release on Github. As releases here don't occur too often, that should hopefully be OK. We might also immediately bump the version as part of this PR and and tag a release. Extrapolating from the API stability this package was able to maintain in the past, calling it 1.0.0 might be an option.