### PR TITLE
Fix dropping of color in printing of the first line in Atom

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -304,16 +304,12 @@ function move_cursor_up_while_clearing_lines(io, numlinesup)
 end
 
 function printover(io::IO, s::AbstractString, color::Symbol = :color_normal)
-    if isdefined(Main, :ESS) || isdefined(Main, :Atom)
-        print(io, "\r")
-        printstyled(io, s; color=color)
-    elseif isdefined(Main, :IJulia)
-        print(io, '\r')
-        printstyled(io, s; color=color) # Jupyter notebooks support ANSI color codes
+    print(io, "\r")
+    printstyled(io, s; color=color)
+    if isdefined(Main, :IJulia)
         Main.IJulia.stdio_bytes[] = 0 # issue #76: circumvent IJulia I/O throttling
+    elseif isdefined(Main, :ESS) || isdefined(Main, :Atom)
     else
-        print(io, "\r")         # go to first column
-        printstyled(io, s; color=color)
         print(io, "\u1b[K")     # clear the rest of the line
     end
 end

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -305,7 +305,8 @@ end
 
 function printover(io::IO, s::AbstractString, color::Symbol = :color_normal)
     if isdefined(Main, :ESS) || isdefined(Main, :Atom)
-        print(io, '\r', s)
+        print(io, "\r")
+        printstyled(io, s; color=color)
     elseif isdefined(Main, :IJulia)
         print(io, '\r')
         printstyled(io, s; color=color) # Jupyter notebooks support ANSI color codes


### PR DESCRIPTION
I noticed that in Atom the first line of the progress bar wasn't printed with color (but additional values provided by `showvalues` are). With this also the first line is now printed with color.