### PR TITLE
Make it possible to set the counter in `ProgressUnknown` by hand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ will yield
 Progress: 53%[==========================>                       ]  ETA: 0:09:02
 ```
 
-### Progress meters for tasks with an unknown number of steps
+### Progress meters for tasks with a target threshold
 
 Some tasks only terminate when some criterion is satisfied, for
 example to achieve convergence within a specified tolerance.  In such

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ circumstances, you can use the `ProgressUnknown` type:
 ```julia
 prog = ProgressUnknown("Titles read:")
 for val in ["a" , "b", "c", "d"]
-    ProgressMeter.update!(prog)
+    ProgressMeter.next!(prog)
     if val == "c"
         ProgressMeter.finish!(prog)
         break
@@ -127,7 +127,7 @@ for val in ["a" , "b", "c", "d"]
     sleep(0.1)
 end
 ```
-This will display the number of calls to `update!` until `finish!` is called.
+This will display the number of calls to `next!` until `finish!` is called.
 
 If your counter does not monotonically increases, you can also set the counter by hand.
 ```julia
@@ -143,8 +143,6 @@ for val in ["aaa" , "bb", "c", "d"]
     sleep(0.5)
 end
 ```
-
-This will display the number of calls to `update!` until `finish!` is called.
 
 ### Printing additional information
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,22 @@ for val in ["a" , "b", "c", "d"]
     sleep(0.1)
 end
 ```
+This will display the number of calls to `update!` until `finish!` is called.
 
+If your counter does not monotonically increases, you can also set the counter by hand.
+```julia
+prog = ProgressUnknown("Total length of characters read:")
+total_length_characters = 0
+for val in ["aaa" , "bb", "c", "d"]
+    global total_length_characters += length(val)
+    ProgressMeter.update!(prog, total_length_characters)
+    if val == "c"
+        ProgressMeter.finish!(prog)
+        break
+    end
+    sleep(0.5)
+end
+```
 
 This will display the number of calls to `update!` until `finish!` is called.
 

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -295,12 +295,12 @@ the current value.
 
 You may optionally change the color of the display. See also `next!`.
 """
-function update!(p::Progress, counter::Int; options...)
+function update!(p::Union{Progress, ProgressUnknown}, counter::Int; options...)
     p.counter = counter
     updateProgress!(p; options...)
 end
 
-function update!(p::Progress, counter::Int, color::Symbol; options...)
+function update!(p::Union{Progress, ProgressUnknown}, counter::Int, color::Symbol; options...)
     p.color = color
     update!(p, counter; options...)
 end
@@ -316,16 +316,12 @@ function update!(p::ProgressThresh, val, color::Symbol; options...)
     update!(p, val; options...)
 end
 
-function update!(p::ProgressUnknown; options...)
-    p.counter += 1
+function update!(p::ProgressUnknown; increasecounter=true, options...)
+    if increasecounter
+        p.counter += 1
+    end
     updateProgress!(p; options...)
 end
-
-function update!(p::ProgressUnknown, color::Symbol; options...)
-    p.color = color
-    update!(p, val; options...)
-end
-
 
 """
 `cancel(prog, [msg], [color=:red])` cancels the progress display

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -274,12 +274,12 @@ or may not result in a change to the display.
 
 You may optionally change the color of the display. See also `update!`.
 """
-function next!(p::Progress; options...)
+function next!(p::Union{Progress, ProgressUnknown}; options...)
     p.counter += 1
     updateProgress!(p; options...)
 end
 
-function next!(p::Progress, color::Symbol; options...)
+function next!(p::Union{Progress, ProgressUnknown}, color::Symbol; options...)
     p.color = color
     next!(p; options...)
 end
@@ -316,12 +316,6 @@ function update!(p::ProgressThresh, val, color::Symbol; options...)
     update!(p, val; options...)
 end
 
-function update!(p::ProgressUnknown; increasecounter=true, options...)
-    if increasecounter
-        p.counter += 1
-    end
-    updateProgress!(p; options...)
-end
 
 """
 `cancel(prog, [msg], [color=:red])` cancels the progress display

--- a/test/test.jl
+++ b/test/test.jl
@@ -246,11 +246,25 @@ for val in 10 .^ range(2, stop=-6, length=20)
     sleep(0.1)
 end
 
-# Threshold-based progress reports
+# ProgressUnknown progress reports
 println("Testing progress unknown")
 prog = ProgressMeter.ProgressUnknown("Reading entry:")
 for _ in 1:10
     ProgressMeter.update!(prog)
+    sleep(0.1)
+end
+ProgressMeter.finish!(prog)
+
+prog = ProgressMeter.ProgressUnknown("Reading entry:")
+for k in 1:2:20
+    ProgressMeter.update!(prog, k)
+    sleep(0.1)
+end
+
+colors = [:red, :blue, :green]
+prog = ProgressMeter.ProgressUnknown("Reading entry:")
+for k in 1:2:20
+    ProgressMeter.update!(prog, k, rand(colors))
     sleep(0.1)
 end
 ProgressMeter.finish!(prog)

--- a/test/test.jl
+++ b/test/test.jl
@@ -250,7 +250,7 @@ end
 println("Testing progress unknown")
 prog = ProgressMeter.ProgressUnknown("Reading entry:")
 for _ in 1:10
-    ProgressMeter.update!(prog)
+    ProgressMeter.next!(prog)
     sleep(0.1)
 end
 ProgressMeter.finish!(prog)

--- a/test/test_showvalues.jl
+++ b/test/test_showvalues.jl
@@ -61,7 +61,7 @@ end
 println("Testing showvalues with online progress")
 prog = ProgressMeter.ProgressUnknown("Entries read:")
 for title in ["a", "b", "c", "d", "e"]
-    ProgressMeter.update!(prog; showvalues = Dict(:title => title))
+    ProgressMeter.next!(prog; showvalues = Dict(:title => title))
     sleep(0.5)
 end
 ProgressMeter.finish!(prog)


### PR DESCRIPTION
This is a follow up to #115. I noticed that I missed two use cases
1) Sometimes you want to increase the counter by more than 1 or even decrease it again
2) Sometimes you want to update additional informations displayed by `showvalues` but not the counter

Both are fixed by adding the possibility to set the counter manually (by the same API as `Progress` already uses).