### PR TITLE
allow one to transition between empty and full

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,24 @@ will yield
 Progress: 53%[==========================>                       ]  ETA: 0:09:02
 ```
 
+It is possible to give a vector of characters that acts like a transition between the empty character
+and the fully filled character. For example, definining the progress bar as:
+
+```julia
+p = Progress(n, dt=0.5,
+             barglyphs=BarGlyphs('|','█', ['▁' ,'▂' ,'▃' ,'▄' ,'▅' ,'▆', '▇'],' ','|',),
+             barlen=10)
+```
+
+might show the progress bar as:
+
+```
+Progress:  34%|███▃      |  ETA: 0:00:02
+```
+
+where the last bar is not yet fully filled.
+
+
 ### Progress meters for tasks with a target threshold
 
 Some tasks only terminate when some criterion is satisfied, for

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -76,7 +76,7 @@ mutable struct Progress <: AbstractProgress
                       color::Symbol=:green,
                       output::IO=stderr,
                       barlen::Integer=tty_width(desc),
-                      barglyphs::BarGlyphs=BarGlyphs('|','█', ['▏','▎','▍','▌','▋','▊','▉'],' ','|',),
+                      barglyphs::BarGlyphs=BarGlyphs('|','█', Sys.iswindows() ? '█' : ['▏','▎','▍','▌','▋','▊','▉'],' ','|',),
                       offset::Int=0)
         counter = 0
         tfirst = tlast = time()

--- a/test/test.jl
+++ b/test/test.jl
@@ -268,3 +268,12 @@ for k in 1:2:20
     sleep(0.1)
 end
 ProgressMeter.finish!(prog)
+
+println("Testing fractional bars")
+for front in (['▏','▎','▍','▌','▋','▊', '▉'], ['▁' ,'▂' ,'▃' ,'▄' ,'▅' ,'▆', '▇'], ['░', '▒', '▓',])
+    p = ProgressMeter.Progress(100, dt=0.01, barglyphs=ProgressMeter.BarGlyphs('|','█',front,' ','|'), barlen=10)
+    for i in 1:100
+        ProgressMeter.next!(p)
+        sleep(0.02)
+    end
+end


### PR DESCRIPTION
Enables slightly smoother progress bar which is nice when the width is not so big.

Link to asciinema below (they seem to have some bug in their monofont width rendering so it shifts a bit but this doesn't happen in the terminal):

https://asciinema.org/a/2BSeu9De6gO8UC05B0jDDx0jI

The first three bars are with a transition and the last one is with the current default.
