### PR TITLE
Fix the elapsed time displaying

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -444,7 +444,7 @@ function durationstring(nsec)
     hours = div(r,60*60)
     r = r - 60*60*hours
     minutes = div(r, 60)
-    seconds = r - 60*minutes
+    seconds = floor(r - 60*minutes)
 
     hhmmss = @sprintf "%u:%02u:%02u" hours minutes seconds
     if days>9

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,0 +1,11 @@
+# test durationstring output at borders
+@test ProgressMeter.durationstring(0.9) == "0:00:00"
+@test ProgressMeter.durationstring(1.0) == "0:00:01"
+@test ProgressMeter.durationstring(59.9) == "0:00:59"
+@test ProgressMeter.durationstring(60.0) == "0:01:00"
+@test ProgressMeter.durationstring(60*60 - 0.1) == "0:59:59"
+@test ProgressMeter.durationstring(60*60) == "1:00:00"
+@test ProgressMeter.durationstring(60*60*24 - 0.1) == "23:59:59"
+@test ProgressMeter.durationstring(60*60*24) == "1 days, 0:00:00"
+@test ProgressMeter.durationstring(60*60*24*10 - 0.1) == "9 days, 23:59:59"
+@test ProgressMeter.durationstring(60*60*24*10) == "10.00 days"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,7 @@
+import ProgressMeter
+using Test
+
+include("core.jl")
 include("test.jl")
 include("test_showvalues.jl")
 include("test_map.jl")

--- a/test/test.jl
+++ b/test/test.jl
@@ -1,6 +1,4 @@
-import ProgressMeter
 using Random: seed!
-using Test
 
 seed!(123)
 


### PR DESCRIPTION
Hi, please take a glance at the screenshot here.

![ss](https://user-images.githubusercontent.com/480049/49941786-76152880-ff1e-11e8-9785-22bb38648e7f.png)

The displayed time in seconds has been rounded up to "60" if it was larger than 59.5. This pr fix this.