### PR TITLE
added alwaysflush option to fix #117

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -69,7 +69,6 @@ mutable struct Progress <: AbstractProgress
     output::IO              # output stream into which the progress is written
     offset::Int             # position offset of progress bar (default is 0)
     numprintedvalues::Int   # num values printed below progress in last iteration
-    alwaysflush::Bool       # if this is true, immediately flush after every printing (see #117)
 
     function Progress(n::Integer;
                       dt::Real=0.1,
@@ -79,12 +78,11 @@ mutable struct Progress <: AbstractProgress
                       barlen::Integer=tty_width(desc),
                       barglyphs::BarGlyphs=BarGlyphs('|','█', Sys.iswindows() ? '█' : ['▏','▎','▍','▌','▋','▊','▉'],' ','|',),
                       offset::Int=0,
-                      alwaysflush::Bool=true
                      )
         counter = 0
         tfirst = tlast = time()
         printed = false
-        new(n, dt, counter, tfirst, tlast, printed, desc, barlen, barglyphs, color, output, offset, 0, alwaysflush)
+        new(n, dt, counter, tfirst, tlast, printed, desc, barlen, barglyphs, color, output, offset, 0)
     end
 end
 
@@ -118,18 +116,16 @@ mutable struct ProgressThresh{T<:Real} <: AbstractProgress
     output::IO           # output stream into which the progress is written
     numprintedvalues::Int   # num values printed below progress in last iteration
     offset::Int             # position offset of progress bar (default is 0)
-    alwaysflush::Bool    # if this is true, immediately flush after every printing (see #117)
 
     function ProgressThresh{T}(thresh;
                                dt::Real=0.1,
                                desc::AbstractString="Progress: ",
                                color::Symbol=:green,
                                output::IO=stderr,
-                               offset::Int=0,
-                               alwaysflush::Bool=true) where T
+                               offset::Int=0) where T
         tfirst = tlast = time()
         printed = false
-        new{T}(thresh, dt, typemax(T), 0, false, tfirst, tlast, printed, desc, color, output, 0, offset, alwaysflush)
+        new{T}(thresh, dt, typemax(T), 0, false, tfirst, tlast, printed, desc, color, output, 0, offset)
     end
 end
 
@@ -160,13 +156,12 @@ mutable struct ProgressUnknown <: AbstractProgress
     color::Symbol        # default to green
     output::IO           # output stream into which the progress is written
     numprintedvalues::Int   # num values printed below progress in last iteration
-    alwaysflush::Bool    # if this is true, immediately flush after every printing (see #117)
 end
 
-function ProgressUnknown(;dt::Real=0.1, desc::AbstractString="Progress: ", color::Symbol=:green, output::IO=stderr, alwaysflush::Bool=true)
+function ProgressUnknown(;dt::Real=0.1, desc::AbstractString="Progress: ", color::Symbol=:green, output::IO=stderr)
     tfirst = tlast = time()
     printed = false
-    ProgressUnknown(false, dt, 0, false, tfirst, tlast, printed, desc, color, output, 0, alwaysflush)
+    ProgressUnknown(false, dt, 0, false, tfirst, tlast, printed, desc, color, output, 0)
 end
 
 ProgressUnknown(dt::Real, desc::AbstractString="Progress: ",
@@ -197,9 +192,7 @@ function updateProgress!(p::Progress; showvalues = Any[], valuecolor = :blue, of
             else
                 print(p.output, "\r\u1b[A" ^ (p.offset + p.numprintedvalues))
             end
-            if p.alwaysflush
-                flush(p.output)
-            end
+            flush(p.output)
         end
         return nothing
     end
@@ -221,9 +214,7 @@ function updateProgress!(p::Progress; showvalues = Any[], valuecolor = :blue, of
         printover(p.output, msg, p.color)
         printvalues!(p, showvalues; color = valuecolor)
         print(p.output, "\r\u1b[A" ^ (p.offset + p.numprintedvalues))
-        if p.alwaysflush
-            flush(p.output)
-        end
+        flush(p.output)
         # Compensate for any overhead of printing. This can be
         # especially important if you're running over a slow network
         # connection.
@@ -251,9 +242,7 @@ function updateProgress!(p::ProgressThresh; showvalues = Any[], valuecolor = :bl
             else
                 print(p.output, "\r\u1b[A" ^ (p.offset + p.numprintedvalues))
             end
-            if p.alwaysflush
-                flush(p.output)
-            end
+            flush(p.output)
         end
         return
     end
@@ -266,9 +255,7 @@ function updateProgress!(p::ProgressThresh; showvalues = Any[], valuecolor = :bl
         printover(p.output, msg, p.color)
         printvalues!(p, showvalues; color = valuecolor)
         print(p.output, "\r\u1b[A" ^ (p.offset + p.numprintedvalues))
-        if p.alwaysflush
-            flush(p.output)
-        end
+        flush(p.output)
         # Compensate for any overhead of printing. This can be
         # especially important if you're running over a slow network
         # connection.
@@ -287,9 +274,7 @@ function updateProgress!(p::ProgressUnknown; showvalues = Any[], valuecolor = :b
             printover(p.output, msg, p.color)
             printvalues!(p, showvalues; color = valuecolor)
             println(p.output)
-            if p.alwaysflush
-                flush(p.output)
-            end
+            flush(p.output)
         end
         return
     end
@@ -300,9 +285,7 @@ function updateProgress!(p::ProgressUnknown; showvalues = Any[], valuecolor = :b
         move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
         printover(p.output, msg, p.color)
         printvalues!(p, showvalues; color = valuecolor)
-        if p.alwaysflush
-            flush(p.output)
-        end
+        flush(p.output)
         # Compensate for any overhead of printing. This can be
         # especially important if you're running over a slow network
         # connection.


### PR DESCRIPTION
By default now whenever this prints the progress meter, it will also flush the stream (see #117). Does everyone else think this is a good idea? Perhaps there are unforeseen consequences of flushing that I have not thought of.