### PR TITLE
Use stdout's displaysize for size computation

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -171,7 +171,7 @@ ProgressUnknown(dt::Real, desc::AbstractString="Progress: ",
 ProgressUnknown(desc::AbstractString) = ProgressUnknown(desc=desc)
 
 #...length of percentage and ETA string with days is 29 characters
-tty_width(desc) = max(0, displaysize()[2] - (length(desc) + 29))
+tty_width(desc) = max(0, displaysize(stdout)[2] - (length(desc) + 29))
 
 # update progress display
 function updateProgress!(p::Progress; showvalues = Any[], valuecolor = :blue, offset::Integer = p.offset, keep = (offset == 0))


### PR DESCRIPTION
Surprisingly, the argumentless default returns the values of the environment variables `ROWS` and `COLUMNS`, which (at least on gnome-terminal) are not necessarily up-to-date with window resizes.
Adding `stdout` gives a result that corresponds to current size.

This prevents the following situation:
![Schermafdruk van 2019-03-24 10-22-49](https://user-images.githubusercontent.com/2110529/54877433-05d04a00-4e1f-11e9-99e7-f0081465abce.png)


A followup feature could be to poll this width to stay up-to-date with window resizes.