### PR TITLE
make @showprogress work with @distributed

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ The first incantation will use a minimum update interval of 1 second, and show t
 
 The `@showprogress` macro wraps a `for` loop, comprehension, or map/pmap as long as the object being iterated over implements the `length` method and will handle `continue` correctly.
 
+The `@showprogressdistributed` macro is the equivalent of `@showprogress` and wraps `@distributed` for loops with a reducer.
+
+```julia
+using Distributed
+using ProgressMeter
+
+result = @showprogressdistributed (+) for i in 1:10
+    sleep(0.1)
+    i^2
+end
+
+result = @showprogressdistributed 1 "Computing..." (+) for i in 1:10
+    sleep(0.1)
+    i^2
+end
+```
+
 You can also control progress updates and reports manually:
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -32,24 +32,23 @@ end
 
 The first incantation will use a minimum update interval of 1 second, and show the ETA and final duration.  If your computation runs so quickly that it never needs to show progress, no extraneous output will be displayed.
 
-The `@showprogress` macro wraps a `for` loop, comprehension, or map/pmap as long as the object being iterated over implements the `length` method and will handle `continue` correctly.
-
-The `@showprogressdistributed` macro is the equivalent of `@showprogress` and wraps `@distributed` for loops with a reducer.
+The `@showprogress` macro wraps a `for` loop, comprehension, `@distributed` for loop, or map/pmap as long as the object being iterated over implements the `length` method and will handle `continue` correctly.
 
 ```julia
 using Distributed
 using ProgressMeter
 
-result = @showprogressdistributed (+) for i in 1:10
+@showprogress @distributed for i in 1:10
     sleep(0.1)
-    i^2
 end
 
-result = @showprogressdistributed 1 "Computing..." (+) for i in 1:10
+result = @showprogress 1 "Computing..." @distributed (+) for i in 1:10
     sleep(0.1)
     i^2
 end
 ```
+
+In the case of a `@distributed` for loop without a reducer, an `@sync` is implied.
 
 You can also control progress updates and reports manually:
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -277,7 +277,7 @@ for front in (['▏','▎','▍','▌','▋','▊', '▉'], ['▁' ,'▂' ,'▃'
 end
 
 function testfunc15(n, dt, tsleep)
-    result = ProgressMeter.@showprogressdistributed dt (+) for i in 1:n
+    result = ProgressMeter.@showprogress dt @distributed (+) for i in 1:n
         if rand() < 0.7
             sleep(tsleep)
         end
@@ -286,6 +286,17 @@ function testfunc15(n, dt, tsleep)
     @test result == sum(abs2.(1:n))
 end
 
-println("Testing @showprogressdistributed macro on for loop")
+println("Testing @showprogress macro on distributed for loop with reducer")
 testfunc15(3000, 0.01, 0.002)
 
+function testfunc16(n, dt, tsleep)
+    ProgressMeter.@showprogress dt "Description: " @distributed for i in 1:n
+        if rand() < 0.7
+            sleep(tsleep)
+        end
+        i ^ 2
+    end
+end
+
+println("Testing @showprogress macro on distributed for loop without reducer")
+testfunc15(3000, 0.01, 0.002)

--- a/test/test.jl
+++ b/test/test.jl
@@ -275,3 +275,17 @@ for front in (['▏','▎','▍','▌','▋','▊', '▉'], ['▁' ,'▂' ,'▃'
         sleep(0.02)
     end
 end
+
+function testfunc15(n, dt, tsleep)
+    result = ProgressMeter.@showprogressdistributed dt (+) for i in 1:n
+        if rand() < 0.7
+            sleep(tsleep)
+        end
+        i ^ 2
+    end
+    @test result == sum(abs2.(1:n))
+end
+
+println("Testing @showprogressdistributed macro on for loop")
+testfunc15(3000, 0.01, 0.002)
+


### PR DESCRIPTION
I find that I often want to use `@distributed` loops with a reducer to compute a result. The code in the "tips for parallel programming" section of the README works well so thought I'd make a macro out of it. If there is a reason for not wanting to put the code from the README in the package then feel free to ignore/close this request. 