### PR TITLE
Add spinlocking for core methods, to support threading (alt to #139)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,14 @@ env:
   matrix:
     - JULIA_NUM_THREADS=1
     - JULIA_NUM_THREADS=3 #3 allows the @spawn test to run effectively
+jobs:
+  exclude:
+  - julia: 0.7 # Disable Threads testing
+    env: JULIA_NUM_THREADS=3
+  - julia: 1.0 # Disable Threads testing
+    env: JULIA_NUM_THREADS=3
+  - julia: 1.1 # Disable Threads testing
+    env: JULIA_NUM_THREADS=3
 # script:
 #   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #   - julia --project -e 'using Pkg; Pkg.build();'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ julia:
   - nightly
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'if VERSION < v"0.7-"; Pkg.clone(pwd()); else; import Pkg; Pkg.add(Pkg.PackageSpec(path=pwd())); end; Pkg.build("ProgressMeter")'
-  - JULIA_NUM_THREADS=2 julia -e 'Pkg.test("ProgressMeter"; coverage=true)'
+  - julia --project -e 'using Pkg; Pkg.build();
+  - JULIA_NUM_THREADS=2 julia --project -e 'Pkg.test(; coverage=true)'
 notifications:
   email: false
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ julia:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --project -e 'using Pkg; Pkg.build();
-  - JULIA_NUM_THREADS=2 julia --project -e 'Pkg.test(; coverage=true)'
+  - JULIA_NUM_THREADS=2 julia --project -e 'using Pkg; Pkg.test(; coverage=true)'
 notifications:
   email: false
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,14 @@ julia:
   - 1.1
   - 1.2
   - nightly
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --project -e 'using Pkg; Pkg.build();'
-  - JULIA_NUM_THREADS=2 julia --project -e 'using Pkg; Pkg.test(; coverage=true)'
+env:
+  matrix:
+    - JULIA_NUM_THREADS=1
+    - JULIA_NUM_THREADS=3 #3 allows the @spawn test to run effectively
+# script:
+#   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#   - julia --project -e 'using Pkg; Pkg.build();'
+#   - JULIA_NUM_THREADS=2 julia --project -e 'using Pkg; Pkg.test(; coverage=true)'
 notifications:
   email: false
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ julia:
   - 1.1
   - 1.2
   - nightly
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'if VERSION < v"0.7-"; Pkg.clone(pwd()); else; import Pkg; Pkg.add(Pkg.PackageSpec(path=pwd())); end; Pkg.build("ProgressMeter")'
+  - JULIA_NUM_THREADS=2 julia -e 'Pkg.test("ProgressMeter"; coverage=true)'
 notifications:
   email: false
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ julia:
   - nightly
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --project -e 'using Pkg; Pkg.build();
+  - julia --project -e 'using Pkg; Pkg.build();'
   - JULIA_NUM_THREADS=2 julia --project -e 'using Pkg; Pkg.test(; coverage=true)'
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -85,6 +85,32 @@ function readFileLines(fileName::String)
 end
 ```
 
+The core methods `Progress()`, `ProgressThresh()`, `ProgressUnknown()`, and their updaters
+are also thread-safe, so can be used with `Threads.@threads`, `Threads.@spawn` etc.:
+
+```julia
+using ProgressMeter
+p = Progress(10)
+Threads.@threads for i in 1:10
+    sleep(2*rand())
+    next!(p)
+end
+```
+
+```julia
+using ProgressMeter
+n = 10
+p = Progress(n)
+tasks = Vector{Task}(undef, n)
+for i in 1:n
+    tasks[i] = Threads.@spawn begin
+        sleep(2*rand())
+        next!(p)
+    end
+end
+wait.(tasks)
+```
+
 ### Progress bar style
 
 Optionally, a description string can be specified which will be prepended to the output, and a progress meter `M` characters long can be shown.  E.g.
@@ -196,7 +222,7 @@ end
 
 ### Tips for parallel programming
 
-When multiple processes or tasks are being used for a computation, the workers should communicate back to a single task for displaying the progress bar. This can be accomplished with a `RemoteChannel`:
+For remote parallelization, when multiple processes or tasks are being used for a computation, the workers should communicate back to a single task for displaying the progress bar. This can be accomplished with a `RemoteChannel`:
 
 ```julia
 using ProgressMeter

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,13 @@
 import ProgressMeter
 using Test
 
-# include("core.jl")
-# include("test.jl")
-# include("test_showvalues.jl")
+include("core.jl")
+include("test.jl")
+include("test_showvalues.jl")
 include("test_map.jl")
-# include("test_float.jl")
+include("test_float.jl")
+include("test_threads.jl")
+
 
 println("")
 println("All tests complete")

--- a/test/test_threads.jl
+++ b/test/test_threads.jl
@@ -1,0 +1,88 @@
+
+@testset "ProgressThreads tests" begin
+    threads = Threads.nthreads()
+    println("Testing Progress() with Threads.@threads across $threads threads")
+    (Threads.nthreads() == 1) && @info "Threads.nthreads() == 1, so Threads.@threads test is suboptimal"
+    n = 20 #per thread
+    threadsUsed = Int[]
+    vals = ones(n*threads)
+    p = ProgressMeter.Progress(n*threads)
+    Threads.@threads for i = 1:(n*threads)
+        !in(Threads.threadid(), threadsUsed) && push!(threadsUsed, Threads.threadid())
+        vals[i] = 0
+        sleep(0.1)
+        ProgressMeter.next!(p)
+    end
+    @test !any(vals .== 1) #Check that all elements have been iterated
+    @test length(threadsUsed) == threads #Ensure that all threads are used
+
+
+    println("Testing ProgressUnknown() with Threads.@threads across $threads threads")
+    trigger = 100.0
+    prog = ProgressMeter.ProgressUnknown("Attepts at exceeding trigger:")
+    vals = Float64[]
+    threadsUsed = Int[]
+    Threads.@threads for _ in 1:1000
+        !in(Threads.threadid(), threadsUsed) && push!(threadsUsed, Threads.threadid())
+        push!(vals, rand())
+        valssum = sum(vals)
+        if sum(vals) <= trigger
+            ProgressMeter.next!(prog)
+        elseif !prog.done
+            ProgressMeter.finish!(prog)
+            break
+        else
+            break
+        end
+        sleep(0.1*rand())
+    end
+    @test sum(vals) > trigger
+    @test length(threadsUsed) == threads #Ensure that all threads are used
+
+
+    println("Testing ProgressThresh() with Threads.@threads across $threads threads")
+    thresh = 1.0
+    prog = ProgressMeter.ProgressThresh(thresh, "Minimizing:")
+    vals = fill(300.0, 1)
+    threadsUsed = Int[]
+    Threads.@threads for _ in 1:100000
+        !in(Threads.threadid(), threadsUsed) && push!(threadsUsed, Threads.threadid())
+        push!(vals, -rand())
+        valssum = sum(vals)
+        if valssum > thresh
+            ProgressMeter.update!(prog, valssum)
+        else
+            ProgressMeter.finish!(prog)
+            break
+        end
+        sleep(0.1*rand())
+    end
+    @test sum(vals) <= thresh
+    @test length(threadsUsed) == threads #Ensure that all threads are used
+
+
+    @static if VERSION >= v"1.3.0-rc1" #Threads.@spawn not available before 1.3
+        if (Threads.nthreads() > 1)
+            threads = Threads.nthreads() - 1
+            println("Testing Progress() with Threads.@spawn across $threads threads")
+            n = 20 #per thread
+            tasks = Vector{Task}(undef, threads)
+            threadsUsed = Int[]
+            vals = ones(n*threads)
+            p = ProgressMeter.Progress(n*threads)
+            for t in 1:threads
+                tasks[t] = Threads.@spawn for i in 1:n
+                    !in(Threads.threadid(), threadsUsed) && push!(threadsUsed, Threads.threadid())
+                    vals[(n*(t-1)) + i] = 0
+                    sleep(0.05 + (rand()*0.1))
+                    ProgressMeter.next!(p)
+                end
+            end
+            wait.(tasks)
+            @test !any(vals .== 1) #Check that all elements have been iterated
+            #@test length(threadsUsed) == threads #Ensure that all threads are used (unreliable for @spawn)
+        else
+            @info "Threads.nthreads() == 1, so Threads.@spawn tests cannot be meaningfully tested"
+        end
+    end
+end


### PR DESCRIPTION
Trying out @KristofferC's suggestion in #139 of just spinlocking by default.

All tests pass locally for me!

```julia
n = 100
p = ProgressMeter.Progress(n)
Threads.@threads for i = 1:(n)
    sleep(0.1)
    ProgressMeter.next!(p)
end
```

I didn't figure out getting `@showprogress` working, but I assume it would follow something like intercepting `@threads` and passing to a custom `showprogressthreads`?