### PR TITLE
add `start` keyword to resume progress from a higher iteration number

### DIFF
--- a/test/test.jl
+++ b/test/test.jl
@@ -198,8 +198,9 @@ function testfunc13()
         ProgressMeter.next!(p)
     end
     # full keyword argumetns
-    p = ProgressMeter.Progress(n, dt=0.01, desc="", color=:red, output=stderr, barlen=40)
-    for i in 1:n
+    start = 15
+    p = ProgressMeter.Progress(n, dt=0.01, desc="", color=:red, output=stderr, barlen=40, start = start)
+    for i in 1:n-start
         sleep(0.1)
         ProgressMeter.next!(p)
     end


### PR DESCRIPTION
Hello!

I wanted the option to (re)start a ProgressMeter from some iteration number higher than 0, so I did some pretty straightforward changes, and then I found out that @gustafsson had a [pull request](https://github.com/timholy/ProgressMeter.jl/pull/94) addressing just this issue.

However, this pull request has been open since 2018, it had a few merge conflicts and also @timholy had suggested the name `start` for the keyword (which I agree) instead of `counterfirst` as proposed by the original author of the request.

Considering the former, I make this pull request over the present master branch to revive the idea and to make it faster/easier for the maintainers to adopt the changes, which can be automatically merged if they agree.

Finally, it seems important to disclaim that even when changes I make here are straightforward, they are very much the same ones proposed by @gustaffson (besides naming), and I do not want, by any means, to steal his work. Any thanks are to him.