### PR TITLE
Ability to update and finish `ProgressThresh` without incrementing the counter

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -350,18 +350,18 @@ function update!(p::Union{Progress, ProgressUnknown}, counter::Int, color::Symbo
     end
 end
 
-function update!(p::ProgressThresh, val; options...)
+function update!(p::ProgressThresh, val; increment::Bool = true, options...)
     lock(p.spinlocker) do
         p.val = val
-        p.counter += 1
+        increment && p.counter += 1
         updateProgress!(p; options...)
     end
 end
 
-function update!(p::ProgressThresh, val, color::Symbol; options...)
+function update!(p::ProgressThresh, val, color::Symbol; increment::Bool = true, options...)
     lock(p.spinlocker) do
         p.val = val
-        p.counter += 1
+        increment && p.counter += 1
         p.color = color
         updateProgress!(p; options...)
     end

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -353,7 +353,9 @@ end
 function update!(p::ProgressThresh, val; increment::Bool = true, options...)
     lock(p.spinlocker) do
         p.val = val
-        increment && p.counter += 1
+        if increment
+            p.counter += 1
+        end
         updateProgress!(p; options...)
     end
 end
@@ -361,7 +363,9 @@ end
 function update!(p::ProgressThresh, val, color::Symbol; increment::Bool = true, options...)
     lock(p.spinlocker) do
         p.val = val
-        increment && p.counter += 1
+        if increment
+            p.counter += 1
+        end
         p.color = color
         updateProgress!(p; options...)
     end

--- a/test/test.jl
+++ b/test/test.jl
@@ -249,12 +249,14 @@ println("Testing threshold-based progress")
 prog = ProgressMeter.ProgressThresh(1e-5, "Minimizing:")
 for val in 10 .^ range(2, stop=-6, length=20)
     ProgressMeter.update!(prog, val; increment=false)
+    @test prog.counter == 0
     sleep(0.1)
 end
 colors = [:red, :blue, :green]
 prog = ProgressMeter.ProgressThresh(1e-5, "Minimizing:")
 for val in 10 .^ range(2, stop=-6, length=20)
     ProgressMeter.update!(prog, val, rand(colors); increment=false)
+    @test prog.counter == 0
     sleep(0.1)
 end
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -244,6 +244,20 @@ for val in 10 .^ range(2, stop=-6, length=20)
     sleep(0.1)
 end
 
+# Threshold-based progress reports with increment=false
+println("Testing threshold-based progress")
+prog = ProgressMeter.ProgressThresh(1e-5, "Minimizing:")
+for val in 10 .^ range(2, stop=-6, length=20)
+    ProgressMeter.update!(prog, val; increment=false)
+    sleep(0.1)
+end
+colors = [:red, :blue, :green]
+prog = ProgressMeter.ProgressThresh(1e-5, "Minimizing:")
+for val in 10 .^ range(2, stop=-6, length=20)
+    ProgressMeter.update!(prog, val, rand(colors); increment=false)
+    sleep(0.1)
+end
+
 # ProgressUnknown progress reports
 println("Testing progress unknown")
 prog = ProgressMeter.ProgressUnknown("Reading entry:")


### PR DESCRIPTION
I often have a situation in which I am doing an optimization problem with some convergence threshold, so I use `ProgressThresh`. This works great:
```julia
julia> optimize(foo, bar)
Maximizing: Time: 0:00:05 (388 iterations)
[ Info: Successfully converged after 388 iterations
```

However, sometimes I also want to enforce a maximum number of iterations, after which I will terminate even if I have not converged. In order to terminate the progress bar in those cases, I call `finish!`, and then I print a warning to the user. Unfortunately, when I call `finish!` on `ProgressThresh`, it increments the counter, even though I did not actually perform an additional iteration. So the output looks like this:
```julia
julia> optimize(foo, bar; max_iterations = 100)
Maximizing: Time: 0:00:01 (101 iterations)
┌ Warning: Failed to converge after 100 iterations
└ @ Main REPL[190]:22
```

As you can see, I performed the maximum number of iterations (100). However, the `ProgressThresh` thinks that I performed 101 iterations, because the call to `finish!` added an additional iteration.

This pull request allows me to call `finish!(prog; increment = false)`, which will finish the progress bar without adding the extra iteration to the counter.