### PR TITLE
Adjust bar length to accommodate updated description

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -199,6 +199,7 @@ clear_ijulia() = (IJULIABEHAVIOR[] != IJuliaAppend) && isdefined(Main, :IJulia) 
 # update progress display
 function updateProgress!(p::Progress; showvalues = (), valuecolor = :blue, offset::Integer = p.offset, keep = (offset == 0), desc = p.desc)
     p.offset = offset
+    p.barlen = p.barlen + (length(p.desc) - length(desc)) #adjust bar length to accomodate new description
     p.desc = desc
     t = time()
     if p.counter >= p.n


### PR DESCRIPTION
An omission from #159 
The bar length wasn't updated to adjust for the different description length, which if the new description was longer could cause the progress bar to spill onto a 2nd line, breaking the in-place update of the progress bar.

This corrects for any change in description length during the `update!`