### PR TITLE
Add ProgressThresh constructor

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -135,9 +135,14 @@ mutable struct ProgressThresh{T<:Real} <: AbstractProgress
     end
 end
 
-ProgressThresh(thresh::Real, dt::Real=0.1, desc::AbstractString="Progress: ",
+ProgressThresh(thresh::Real, dt::Real, desc::AbstractString="Progress: ",
          color::Symbol=:green, output::IO=stderr;
          offset::Integer=0) =
+    ProgressThresh{typeof(thresh)}(thresh, dt=dt, desc=desc, color=color, output=output, offset=offset)
+
+ProgressThresh(thresh::Real; dt::Real=0.1, desc::AbstractString="Progress: ",
+        color::Symbol=:green, output::IO=stderr,
+        offset::Int=0) = 
     ProgressThresh{typeof(thresh)}(thresh, dt=dt, desc=desc, color=color, output=output, offset=offset)
 
 ProgressThresh(thresh::Real, desc::AbstractString, offset::Integer=0) = ProgressThresh{typeof(thresh)}(thresh, desc=desc, offset=offset)


### PR DESCRIPTION
Hi, this is the issue
```
julia> ProgressThresh(1.0; desc = "Desc: ")
ERROR: MethodError: no method matching ProgressThresh(::Float64, ::Float64, ::String, ::Symbol, ::Base.TTY; desc="Desc: ")
[...]
```

But, the help is a little confusing here
```
help?> ProgressThresh
search: ProgressThresh

  prog = ProgressThresh(thresh; dt=0.1, desc="Progress: ", color=:green, output=stderr) creates a progress meter for a task which will terminate once a value less than or equal
  to thresh is reached. Output will be generated at intervals at least dt seconds apart, and perhaps longer if each iteration takes longer than dt. desc is a description of the
  current task.
```

It took me a while to realize that it was because it is a parameterized type. So, this works
```
julia> ProgressThresh{Float64}(1.0; desc = "Desc: ")
ProgressThresh{Float64}(1.0, ReentrantLock(nothing...
[...]
```
There is already a constructor that allow you to use the type of `thresh`, I just add another for the kwarg version.

Thanks!!