### PR TITLE
Allow passing a function for lazy-showvalues

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ generate_showvalues(iter, x) = () -> [(:iter,iter), (:x,x)]
 for iter = 1:10
     x *= 2
     sleep(0.5)
-    ProgressMeter.next!(p; showvalues = generate_showvalues(iter, x))
+# unlike `showvalues=generate_showvalues(iter, x)()`, this version only evaluate the function when necessary
+ProgressMeter.next!(p; showvalues = generate_showvalues(iter, x))
 end**
 ```
 

--- a/README.md
+++ b/README.md
@@ -225,9 +225,7 @@ for iter = 1:10
 end
 ```
 
-In the above example `showvalues` keyword is evaluated in each iteration, regardless
-if the progress will be reprinted or not. For avoiding that and prevent overhead a
-zero-argument function can be passed that returns the `showvalues` object.
+In the above example, the data passed to `showvalues` is evaluated even if the progress bar is not updated. To avoid this unnecessary computation and reduce the overhead you can alternatively pass a zero-argument function as a callback to the `showvalues` keyword.
 
 ```julia
 x,n = 1,10

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ if the progress will be reprinted or not. For avoiding that and prevent overhead
 zero-argument function can be passed that returns the `showvalues` object.
 
 ```julia
-**x,n = 1,10
+x,n = 1,10
 p = Progress(n)
 generate_showvalues(iter, x) = () -> [(:iter,iter), (:x,x)]
 for iter = 1:10

--- a/README.md
+++ b/README.md
@@ -225,6 +225,21 @@ for iter = 1:10
 end
 ```
 
+In the above example `showvalues` keyword is evaluated in each iteration, regardless
+if the progress will be reprinted or not. For avoiding that and prevent overhead a
+zero-argument function can be passed that returns the `showvalues` object.
+
+```julia
+**x,n = 1,10
+p = Progress(n)
+generate_showvalues(iter, x) = () -> [(:iter,iter), (:x,x)]
+for iter = 1:10
+    x *= 2
+    sleep(0.5)
+    ProgressMeter.next!(p; showvalues = generate_showvalues(iter, x))
+end**
+```
+
 #### ProgressMeter with additional information in Jupyter
 
 Jupyter notebooks/lab does not allow one to overwrite only parts of the output of cell.

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -456,6 +456,9 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p
 end
 
+# Internal method to print additional values below progress bar (lazy-showvalues version) 
+printvalues!(p::AbstractProgress, showvalues::Function; kwargs...) = printvalues!(p, showvalues(); kwargs...)
+
 function move_cursor_up_while_clearing_lines(io, numlinesup)
     if numlinesup > 0 && clear_ijulia()
         Main.IJulia.clear_output(true)

--- a/test/test_showvalues.jl
+++ b/test/test_showvalues.jl
@@ -2,12 +2,16 @@ for ijulia_behavior in [:warn, :clear, :append]
 
 ProgressMeter.ijulia_behavior(ijulia_behavior)
 
+# For testing lazy-showvalue too
+lazy_no_lazy(values) = (rand() < 0.5) ? values : () -> values
+
 println("Testing showvalues with a Dict (2 values)")
 function testfunc1(n, dt, tsleep, desc, barlen)
     p = ProgressMeter.Progress(n, dt, desc, barlen)
     for i = 1:n
         sleep(tsleep)
-        ProgressMeter.next!(p; showvalues = Dict(:i => i, :halfdone => (i >= n/2)))
+        values = Dict(:i => i, :halfdone => (i >= n/2))
+        ProgressMeter.next!(p; showvalues = lazy_no_lazy(values))
     end
 end
 testfunc1(50, 1, 0.2, "progress  ", 70)
@@ -17,8 +21,8 @@ function testfunc2(n, dt, tsleep, desc, barlen)
     p = ProgressMeter.Progress(n, dt, desc, barlen)
     for i = 1:n
         sleep(tsleep)
-        ProgressMeter.next!(p; showvalues = [(:i, i),
-            (:constant, "foo"), (:isq, i^2), (:large, 2^i)])
+        values = [(:i, i), (:constant, "foo"), (:isq, i^2), (:large, 2^i)]
+        ProgressMeter.next!(p; showvalues = lazy_no_lazy(values))
     end
 end
 testfunc2(30, 1, 0.2, "progress  ", 60)
@@ -28,8 +32,9 @@ function testfunc3(n, dt, tsleep, desc, barlen)
     p = ProgressMeter.Progress(n, dt, desc, barlen)
     for i = 1:n
         sleep(tsleep)
-        ProgressMeter.next!(p; showvalues = [(:i, i*10), ("constant", "foo"),
-            ("foobar", round(i*tsleep, digits=4))])
+        values = [(:i, i*10), ("constant", "foo"), 
+            ("foobar", round(i*tsleep, digits=4))]
+        ProgressMeter.next!(p; showvalues = lazy_no_lazy(values))
     end
 end
 testfunc3(30, 1, 0.2, "progress  ", 70)
@@ -39,8 +44,10 @@ function testfunc4(n, dt, tsleep, desc, barlen)
     p = ProgressMeter.Progress(n, dt, desc, barlen)
     for i = 1:n
         sleep(tsleep)
-        values = [(:i, i*10), ("constant", "foo"), ("foobar", round(i*tsleep, digits=4))]
-        ProgressMeter.next!(p; showvalues = values[randn(3) .< 0.5])
+        values_pool = [(:i, i*10), ("constant", "foo"), 
+            ("foobar", round(i*tsleep, digits=4))]
+        values = values_pool[randn(3) .< 0.5]
+        ProgressMeter.next!(p; showvalues = lazy_no_lazy(values))
     end
 end
 testfunc4(30, 1, 0.2, "opt steps  ", 70)
@@ -49,9 +56,9 @@ println("Testing showvalues with changing number of lines")
 prog = ProgressMeter.Progress(50)
 for i in 1:50
     values = Dict(:left => 100 - i,
-                  :message => repeat("0123456789", (i%10 + 1)*15),
-                  :final => "this comes after")
-    ProgressMeter.update!(prog, i; showvalues = values)
+                    :message => repeat("0123456789", (i%10 + 1)*15),
+                    :final => "this comes after")
+    ProgressMeter.update!(prog, i; showvalues = lazy_no_lazy(values))
     sleep(0.1)
 end
 
@@ -60,7 +67,9 @@ function testfunc5(n, dt, tsleep, desc, barlen)
     p = ProgressMeter.Progress(n, dt, desc, barlen)
     for i = 1:n
         sleep(tsleep)
-        ProgressMeter.next!(p; showvalues = [(:large, 2^i)], valuecolor = :yellow)
+        values = [(:large, 2^i)]
+        ProgressMeter.next!(p; showvalues = lazy_no_lazy(values), 
+            valuecolor = :yellow)
     end
 end
 testfunc5(10, 1, 0.2, "progress  ", 40)
@@ -68,14 +77,16 @@ testfunc5(10, 1, 0.2, "progress  ", 40)
 println("Testing showvalues with threshold-based progress")
 prog = ProgressMeter.ProgressThresh(1e-5, "Minimizing:")
 for val in 10 .^ range(2, stop=-6, length=20)
-    ProgressMeter.update!(prog, val; showvalues = Dict(:margin => abs(val - 1e-5)))
+    values = Dict(:margin => abs(val - 1e-5))
+    ProgressMeter.update!(prog, val; showvalues = lazy_no_lazy(values))
     sleep(0.1)
 end
 
 println("Testing showvalues with online progress")
 prog = ProgressMeter.ProgressUnknown("Entries read:")
 for title in ["a", "b", "c", "d", "e"]
-    ProgressMeter.next!(prog; showvalues = Dict(:title => title))
+    values = Dict(:title => title)
+    ProgressMeter.next!(prog; showvalues = lazy_no_lazy(values))
     sleep(0.5)
 end
 ProgressMeter.finish!(prog)
@@ -84,7 +95,8 @@ ProgressMeter.finish!(prog)
 println("Testing showvalues with early cancel")
 prog = ProgressMeter.Progress(100, 1, "progress: ", 70)
 for i in 1:50
-    ProgressMeter.update!(prog, i; showvalues = Dict(:left => 100 - i))
+    values = Dict(:left => 100 - i)
+    ProgressMeter.update!(prog, i; showvalues = lazy_no_lazy(values))
     sleep(0.1)
 end
 ProgressMeter.cancel(prog)
@@ -93,9 +105,9 @@ ProgressMeter.cancel(prog)
 println("Testing showvalues with truncate")
 prog = ProgressMeter.Progress(50, 1, "progress: ")
 for i in 1:50
-    values = Dict(:left => 100 - i,
-                  :message => repeat("0123456789", i))
-    ProgressMeter.update!(prog, i; showvalues = values, truncate_lines = true)
+    values = Dict(:left => 100 - i, :message => repeat("0123456789", i))
+    ProgressMeter.update!(prog, i; 
+        showvalues = lazy_no_lazy(values), truncate_lines = true)
     sleep(0.1)
 end
 


### PR DESCRIPTION
Hi, 
`update!` and `next!` are methods so its arguments will be evaluated in every call. 
Sometimes I want to show values that are computed on the fly, and it is a waste of time to
 compute them if the progress won't be reprinted. 
So I just add a version of `printvalues!` that takes a zero-argument function as `showvalues`
so it will be evaluated just in case of re-printing.

An illustrative example
```julia
@info "Current: showvalue evaluates each iter"
@time let
    prog = Progress(10; dt = 1.0);
    for i = 1:10

        # Computation
        sleep(3/10) # add 3 seconds
        next!(prog; showvalues = [
                ("heavy val", (sleep(3/10); i)) # adds 3 additional seconds
            ]
        )
    end
    finish!(prog)
end
#= 
[ Info: Current: showvalue evaluates each iter
Progress: 100%|█████████████████████████████| Time: 0:00:06
  heavy val:  10
  6.289688 seconds (156.40 k allocations: 7.480 MiB)
=#

@info "Lazy: showvalue is a function evaluated only when updated"
@time let
    prog = Progress(10; dt = 1.0);
    for i = 1:10

        # Computation
        sleep(3/10) # add to 3 seconds
        next!(prog; showvalues = () -> [
                ("heavy val", (sleep(3/10); i)) # it is evaluated ~3 times so add an extra 1 second
            ]
        )
    end
    finish!(prog)
end
#= 
[ Info: Lazy: showvalue is a function evaluated only when updated
Progress: 100%|█████████████████████████████| Time: 0:00:04
  heavy val:  10
  4.418721 seconds (439.13 k allocations: 23.509 MiB)
=#
```

Thanks!!