### PR TITLE
make output optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ end
 end
 ```
 
-The first incantation will use a minimum update interval of 1 second, and show the ETA and final duration.  If your computation runs so quickly that it never needs to show progress, no extraneous output will be displayed.
+The first incantation will use a minimum update interval of 1 second, and show the ETA and
+final duration.  If your computation runs so quickly that it never needs to show progress,
+no extraneous output will be displayed.
 
-The `@showprogress` macro wraps a `for` loop, comprehension, `@distributed` for loop, or `map`/`pmap`/`reduce` as long as the object being iterated over implements the `length` method and will handle `continue` correctly.
+The `@showprogress` macro wraps a `for` loop, comprehension, `@distributed` for loop, or
+`map`/`pmap`/`reduce` as long as the object being iterated over implements the `length`
+method and will handle `continue` correctly.
 
 ```julia
 using Distributed
@@ -68,7 +72,8 @@ function my_long_running_function(filenames::Array)
 end
 ```
 
-For tasks such as reading file data where the progress increment varies between iterations, you can use `update!`:
+For tasks such as reading file data where the progress increment varies between iterations,
+you can use `update!`:
 
 ```julia
 using ProgressMeter
@@ -118,7 +123,8 @@ wait.(tasks)
 
 ### Progress bar style
 
-Optionally, a description string can be specified which will be prepended to the output, and a progress meter `M` characters long can be shown.  E.g.
+Optionally, a description string can be specified which will be prepended to the output,
+and a progress meter `M` characters long can be shown.  E.g.
 
 ```julia
 p = Progress(n, 1, "Computing initial pass...", 50)
@@ -132,7 +138,9 @@ Computing initial pass...53%|█████████████████
 
 in a manner similar to [python-progressbar](https://code.google.com/p/python-progressbar/).
 
-Also, other properties can be modified through keywords. The glyphs used in the bar may be specified by passing a `BarGlyphs` object as the keyword argument `barglyphs`. The `BarGlyphs` constructor can either take 5 characters as arguments or a single 5 character string. E.g.
+Also, other properties can be modified through keywords. The glyphs used in the bar may be
+specified by passing a `BarGlyphs` object as the keyword argument `barglyphs`. The `BarGlyphs`
+constructor can either take 5 characters as arguments or a single 5 character string. E.g.
 
 ```julia
 p = Progress(n, dt=0.5, barglyphs=BarGlyphs("[=> ]"), barlen=50, color=:yellow)
@@ -144,8 +152,8 @@ will yield
 Progress: 53%[==========================>                       ]  ETA: 0:09:02
 ```
 
-It is possible to give a vector of characters that acts like a transition between the empty character
-and the fully filled character. For example, definining the progress bar as:
+It is possible to give a vector of characters that acts like a transition between the empty
+character and the fully filled character. For example, definining the progress bar as:
 
 ```julia
 p = Progress(n, dt=0.5,
@@ -160,7 +168,6 @@ Progress:  34%|███▃      |  ETA: 0:00:02
 ```
 
 where the last bar is not yet fully filled.
-
 
 ### Progress meters for tasks with a target threshold
 
@@ -192,9 +199,11 @@ for val in ["a" , "b", "c", "d"]
     sleep(0.1)
 end
 ```
+
 This will display the number of calls to `next!` until `finish!` is called.
 
 If your counter does not monotonically increases, you can also set the counter by hand.
+
 ```julia
 prog = ProgressUnknown("Total length of characters read:")
 total_length_characters = 0
@@ -225,17 +234,20 @@ for iter = 1:10
 end
 ```
 
-#### ProgressMeter with additional information in Jupyter
+### ProgressMeter with additional information in Jupyter
 
 Jupyter notebooks/lab does not allow one to overwrite only parts of the output of cell.
 In releases up through 1.2, progress bars are printed repeatedly to the output.
-Starting with release xx, by default Jupyter clears the output of a cell, but this will remove **all** output from the cell.
-You can restore previous behavior by calling `ProgressMeter.ijulia_behavior(:append)`. 
-You can enable it again by calling `ProgressMeter.ijulia_behavior(:clear)`, which will also disable the warning message.
+Starting with release xx, by default Jupyter clears the output of a cell, but this will
+remove **all** output from the cell. You can restore previous behavior by calling
+`ProgressMeter.ijulia_behavior(:append)`. You can enable it again by calling `ProgressMeter.ijulia_behavior(:clear)`,
+which will also disable the warning message.
 
 ### Tips for parallel programming
 
-For remote parallelization, when multiple processes or tasks are being used for a computation, the workers should communicate back to a single task for displaying the progress bar. This can be accomplished with a `RemoteChannel`:
+For remote parallelization, when multiple processes or tasks are being used for a computation,
+the workers should communicate back to a single task for displaying the progress bar. This
+can be accomplished with a `RemoteChannel`:
 
 ```julia
 using ProgressMeter
@@ -264,7 +276,8 @@ end
 
 ### `progress_map`
 
-More control over the progress bar in a map function can be achieved with the `progress_map` and `progress_pmap` functions. The keyword argument `progress` can be used to supply a custom progress meter.
+More control over the progress bar in a map function can be achieved with the `progress_map`
+and `progress_pmap` functions. The keyword argument `progress` can be used to supply a custom progress meter.
 
 ```julia
 p = Progress(10, barglyphs=BarGlyphs("[=> ]"))
@@ -273,6 +286,27 @@ progress_map(1:10, progress=p) do x
     x^2
 end
 ```
+
+### Optional use of the progress meter
+
+It possible to disable the progress meter when the use is optional.
+
+```julia
+x,n = 1,10
+p = Progress(n; disable = true)
+for iter = 1:10
+    x *= 2
+    sleep(0.5)
+    ProgressMeter.next!(p)
+end
+```
+
+In cases where the output is text output such as CI or in an HPC scheduler, the helper function
+`is_logging` can be used to disable automatically.
+
+```julia
+p = Progress(n; output = stderr, disable = is_logging(stderr))
+````
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ In cases where the output is text output such as CI or in an HPC scheduler, the 
 `is_logging` can be used to disable automatically.
 
 ```julia
+is_logging(io) = isa(io, Base.TTY) == false || (get(ENV, "CI", nothing) == "true")
 p = Progress(n; output = stderr, disable = is_logging(stderr))
 ````
 

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -202,11 +202,12 @@ function ijulia_behavior(b)
 end
 
 # Whether or not to use IJulia.clear_output
-clear_ijulia() = (IJULIABEHAVIOR[] != IJuliaAppend) && isdefined(Main, :IJulia) && Main.IJulia.inited
+running_ijulia_kernel() = isdefined(Main, :IJulia) && Main.IJulia.inited
+clear_ijulia() = (IJULIABEHAVIOR[] != IJuliaAppend) && running_ijulia_kernel()
 
 # update progress display
 function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, valuecolor = :blue, offset::Integer = p.offset, keep = (offset == 0), desc::Union{Nothing,AbstractString} = nothing)
-    !p.io_is_tty && return
+    (!running_ijulia_kernel() & !p.io_is_tty) && return
     if desc !== nothing
         if p.barlen !== nothing
             p.barlen += length(p.desc) - length(desc) #adjust bar length to accommodate new description
@@ -265,7 +266,7 @@ function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, v
 end
 
 function updateProgress!(p::ProgressThresh; showvalues = (), truncate_lines = false, valuecolor = :blue, offset::Integer = p.offset, keep = (offset == 0), desc = p.desc)
-    !p.io_is_tty && return
+    (!running_ijulia_kernel() & !p.io_is_tty) && return
     p.offset = offset
     p.desc = desc
     t = time()
@@ -307,7 +308,7 @@ function updateProgress!(p::ProgressThresh; showvalues = (), truncate_lines = fa
 end
 
 function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = false, valuecolor = :blue, desc = p.desc)
-    !p.io_is_tty && return
+    (!running_ijulia_kernel() & !p.io_is_tty) && return
     p.desc = desc
     t = time()
     if p.done

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -3,7 +3,7 @@ module ProgressMeter
 using Printf: @sprintf
 using Distributed
 
-export Progress, ProgressThresh, ProgressUnknown, BarGlyphs, next!, update!, cancel, finish!, @showprogress, progress_map, progress_pmap, ijulia_behavior, is_logging
+export Progress, ProgressThresh, ProgressUnknown, BarGlyphs, next!, update!, cancel, finish!, @showprogress, progress_map, progress_pmap, ijulia_behavior
 
 """
 `ProgressMeter` contains a suite of utilities for displaying progress
@@ -19,8 +19,6 @@ are:
 ProgressMeter
 
 abstract type AbstractProgress end
-
-
 
 """
 Holds the five characters that will be used to generate the progress bar.
@@ -47,9 +45,6 @@ function BarGlyphs(s::AbstractString)
     end
     return BarGlyphs(glyphs...)
 end
-
-
-is_logging(io) = isa(io, Base.TTY) == false || (get(ENV, "CI", nothing) == "true")
 
 """
 `prog = Progress(n; dt=0.1, desc="Progress: ", color=:green,

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -81,7 +81,7 @@ mutable struct Progress <: AbstractProgress
                       barglyphs::BarGlyphs=BarGlyphs('|','█', Sys.iswindows() ? '█' : ['▏','▎','▍','▌','▋','▊','▉'],' ','|',),
                       offset::Integer=0,
                       start::Integer=0,
-                      enabled = true
+                      enabled::Bool = true
                      )
         reentrantlocker = Threads.ReentrantLock()
         counter = start
@@ -171,7 +171,7 @@ mutable struct ProgressUnknown <: AbstractProgress
     enabled::Bool
 end
 
-function ProgressUnknown(;dt::Real=0.1, desc::AbstractString="Progress: ", color::Symbol=:green, output::IO=stderr, enabled = true)
+function ProgressUnknown(;dt::Real=0.1, desc::AbstractString="Progress: ", color::Symbol=:green, output::IO=stderr, enabled::Bool = true)
     reentrantlocker = Threads.ReentrantLock()
     tfirst = tlast = time()
     printed = false


### PR DESCRIPTION
This PR detects if the IO is a file or TTY and prevents printing the progress bars to file in cases like when running in an HPC with a SLURM schedule that the logs get full of noisy output. 