### PR TITLE
Fix keyword argument to enable/disable progress meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ for iter = 1:10
     sleep(0.5)
 # unlike `showvalues=generate_showvalues(iter, x)()`, this version only evaluate the function when necessary
 ProgressMeter.next!(p; showvalues = generate_showvalues(iter, x))
-end**
+end
 ```
 
 ### ProgressMeter with additional information in Jupyter
@@ -307,7 +307,7 @@ It possible to disable the progress meter when the use is optional.
 
 ```julia
 x,n = 1,10
-p = Progress(n; disable = true)
+p = Progress(n; enabled = false)
 for iter = 1:10
     x *= 2
     sleep(0.5)
@@ -320,7 +320,7 @@ In cases where the output is text output such as CI or in an HPC scheduler, the 
 
 ```julia
 is_logging(io) = isa(io, Base.TTY) == false || (get(ENV, "CI", nothing) == "true")
-p = Progress(n; output = stderr, disable = is_logging(stderr))
+p = Progress(n; output = stderr, enabled = !is_logging(stderr))
 ````
 
 ## Credits


### PR DESCRIPTION
This fixes #187. The `enabled` keyword argument to allow disabling the progress meter was introduced in #185 but the README wasn't updated to use the `enabled` keyword argument that was settled upon in the PR.

This also removes a spurious `**`.