### PR TITLE
Add an option to show per-iteration speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Progress:  XX%|█████████████████████�
 
 ## Conditionally disabling a progress meter
 
-In addition to the `showspeed` optional keyword arument, all the progress meters also support the optional `enable` keyword argument. You can use this to conditionally disable a progress bar in cases where you want less verbose output or are using another progress bar to track progress in looping over a function that itself uses a progress bar.
+In addition to the `showspeed` optional keyword argument, all the progress meters also support the optional `enable` keyword argument. You can use this to conditionally disable a progress bar in cases where you want less verbose output or are using another progress bar to track progress in looping over a function that itself uses a progress bar.
 
 ```julia
 function my_awesome_slow_loop(n: Integer; show_progress=true)

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ ProgressMeter.next!(p; showvalues = generate_showvalues(iter, x))
 end**
 ```
 
-## Showing average time per iteration
+### Showing average time per iteration
 
 You can include an average per-iteration duration in your progress meter by setting the optional keyword argument `showspeed=true` when constructing a `Progress`, `ProgressUnknown`, or `ProgressThresh`.
 
@@ -274,7 +274,7 @@ instead of
 Progress:  XX%|███████████████████████████                         |  ETA: XX:YY:ZZ
 ```
 
-## Conditionally disabling a progress meter
+### Conditionally disabling a progress meter
 
 In addition to the `showspeed` optional keyword argument, all the progress meters also support the optional `enable` keyword argument. You can use this to conditionally disable a progress bar in cases where you want less verbose output or are using another progress bar to track progress in looping over a function that itself uses a progress bar.
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,57 @@ ProgressMeter.next!(p; showvalues = generate_showvalues(iter, x))
 end**
 ```
 
+## Showing average time per iteration
+
+You can include an average per-iteration duration in your progress meter by setting the optional keyword argument `showspeed=true` when constructing a `Progress`, `ProgressUnknown`, or `ProgressThresh`.
+
+```julia
+x,n = 1,10
+p = Progress(n; showspeed=true)
+for iter = 1:10
+    x *= 2
+    sleep(0.5)
+    ProgressMeter.next!(p; showvalues = [(:iter,iter), (:x,x)])
+end
+```
+
+will yield something like:
+
+```
+Progress:  XX%|███████████████████████████           |  ETA: XX:YY:ZZ (12.34  s/it)
+```
+
+instead of
+
+```
+Progress:  XX%|███████████████████████████                         |  ETA: XX:YY:ZZ
+```
+
+## Conditionally disabling a progress meter
+
+In addition to the `showspeed` optional keyword arument, all the progress meters also support the optional `enable` keyword argument. You can use this to conditionally disable a progress bar in cases where you want less verbose output or are using another progress bar to track progress in looping over a function that itself uses a progress bar.
+
+```julia
+function my_awesome_slow_loop(n: Integer; show_progress=true)
+    p = Progress(n; enable=show_progress)
+    for i in 1:n
+        sleep(0.1)
+        next!(p)
+    end
+end
+
+const SHOW_PROGRESS_BARS = parse(Bool, get(ENV, "PROGRESS_BARS", "true"))
+
+m = 100
+# let environment variable disable outer loop progress bar
+p = Progress(m; enable=SHOW_PROGRESS_BARS)
+for i in 1:m
+    # disable inner loop progress bar since we are tracking progress in the outer loop
+    my_awesome_slow_loop(i; show_progress=false)
+    next!(p)
+end
+```
+
 ### ProgressMeter with additional information in Jupyter
 
 Jupyter notebooks/lab does not allow one to overwrite only parts of the output of cell.

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -137,7 +137,7 @@ mutable struct ProgressThresh{T<:Real} <: AbstractProgress
                                output::IO=stderr,
                                offset::Integer=0,
                                enabled = true,
-                               showspeed::Bool = true) where T
+                               showspeed::Bool = false) where T
         RUNNING_IJULIA_KERNEL[] = running_ijulia_kernel()
         CLEAR_IJULIA[] = clear_ijulia()
         reentrantlocker = Threads.ReentrantLock()
@@ -197,7 +197,13 @@ ProgressUnknown(dt::Real, desc::AbstractString="Progress: ",
 ProgressUnknown(desc::AbstractString) = ProgressUnknown(desc=desc)
 
 #...length of percentage and ETA string with days is 29 characters
-tty_width(desc, output) = max(0, (displaysize(output)::Tuple{Int,Int})[2] - (length(desc) + 29))
+function tty_width(desc, output, showspeed::Bool)
+    full_width = displaysize(output)[2]
+    desc_width = length(desc)
+    eta_width = 29
+    speed_width = showspeed ? 13 : 0
+    return max(0, full_width - desc_width - eta_width - speed_width)
+end
 
 # Package level behavior of IJulia clear output
 @enum IJuliaBehavior IJuliaWarned IJuliaClear IJuliaAppend
@@ -233,11 +239,16 @@ function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, v
     t = time()
     if p.counter >= p.n
         if p.counter == p.n && p.printed
-            barlen = p.barlen isa Nothing ? tty_width(p.desc, p.output) : p.barlen
+            barlen = p.barlen isa Nothing ? tty_width(p.desc, p.output, p.showspeed) : p.barlen
             percentage_complete = 100.0 * p.counter / p.n
             bar = barstring(barlen, percentage_complete, barglyphs=p.barglyphs)
-            dur = durationstring(t - p.tinit)
+            elapsed_time = t - p.tinit
+            dur = durationstring(elapsed_time)
             msg = @sprintf "%s%3u%%%s Time: %s" p.desc round(Int, percentage_complete) bar dur
+            if p.showspeed
+                sec_per_iter = elapsed_time / (p.counter - p.start)
+                msg = @sprintf "%s (%s)" msg speedstring(sec_per_iter)
+            end
             !CLEAR_IJULIA[] && print(p.output, "\n" ^ (p.offset + p.numprintedvalues))
             move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
             printover(p.output, msg, p.color)
@@ -253,7 +264,7 @@ function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, v
     end
 
     if t > p.tlast+p.dt
-        barlen = p.barlen isa Nothing ? tty_width(p.desc, p.output) : p.barlen
+        barlen = p.barlen isa Nothing ? tty_width(p.desc, p.output, p.showspeed) : p.barlen
         percentage_complete = 100.0 * p.counter / p.n
         bar = barstring(barlen, percentage_complete, barglyphs=p.barglyphs)
         elapsed_time = t - p.tsecond # ignore the first loop given usually uncharacteristically slow
@@ -265,6 +276,10 @@ function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, v
             eta = "N/A"
         end
         msg = @sprintf "%s%3u%%%s  ETA: %s" p.desc round(Int, percentage_complete) bar eta
+        if p.showspeed
+            sec_per_iter = elapsed_time / (p.counter - p.start)
+            msg = @sprintf "%s (%s)" msg speedstring(sec_per_iter)
+        end
         !CLEAR_IJULIA[] && print(p.output, "\n" ^ (p.offset + p.numprintedvalues))
         move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
         printover(p.output, msg, p.color)
@@ -289,8 +304,13 @@ function updateProgress!(p::ProgressThresh; showvalues = (), truncate_lines = fa
         p.triggered = true
         if p.printed
             p.triggered = true
-            dur = durationstring(t-p.tinit)
+            elapsed_time = t - p.tinit
+            dur = durationstring(elapsed_time)
             msg = @sprintf "%s Time: %s (%d iterations)" p.desc dur p.counter
+            if p.showspeed
+                sec_per_iter = elapsed_time / p.counter
+                msg = @sprintf "%s (%s)" msg speedstring(sec_per_iter)
+            end
             print(p.output, "\n" ^ (p.offset + p.numprintedvalues))
             move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
             printover(p.output, msg, p.color)
@@ -307,6 +327,10 @@ function updateProgress!(p::ProgressThresh; showvalues = (), truncate_lines = fa
 
     if t > p.tlast+p.dt && !p.triggered
         msg = @sprintf "%s (thresh = %g, value = %g)" p.desc p.thresh p.val
+        if p.showspeed
+            sec_per_iter = elapsed_time / p.counter
+            msg = @sprintf "%s (%s)" msg speedstring(sec_per_iter)
+        end
         print(p.output, "\n" ^ (p.offset + p.numprintedvalues))
         move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
         printover(p.output, msg, p.color)
@@ -327,8 +351,13 @@ function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = f
     t = time()
     if p.done
         if p.printed
-            dur = durationstring(t-p.tinit)
+            elapsed_time = t - p.tinit
+            dur = durationstring(elapsed_time)
             msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
+            if p.showspeed
+                sec_per_iter = elapsed_time / p.counter
+                msg = @sprintf "%s (%s)" msg speedstring(sec_per_iter)
+            end
             move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
             printover(p.output, msg, p.color)
             printvalues!(p, showvalues; color = valuecolor, truncate = truncate_lines)
@@ -339,8 +368,13 @@ function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = f
     end
 
     if t > p.tlast+p.dt
-        dur = durationstring(t-p.tinit)
+        elapsed_time = t - p.tinit
+        dur = durationstring(elapsed_time)
         msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
+        if p.showspeed
+            sec_per_iter = elapsed_time / p.counter
+            msg = @sprintf "%s (%s)" msg speedstring(sec_per_iter)
+        end
         move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
         printover(p.output, msg, p.color)
         printvalues!(p, showvalues; color = valuecolor, truncate = truncate_lines)
@@ -548,6 +582,27 @@ function durationstring(nsec)
         return @sprintf "%u days, %s" days hhmmss
     end
     hhmmss
+end
+
+function speedstring(sec_per_iter)
+    if sec_per_iter == Inf
+        return "  N/A  s/it"
+    end
+    ns_per_iter = 1_000_000_000 * sec_per_iter
+    for (divideby, unit) in (
+        (1, "ns"),
+        (1_000, "μs"),
+        (1_000_000, "ms"),
+        (1_000_000_000, "s"),
+        (60 * 1_000_000_000, "m"),
+        (60 * 60 * 1_000_000_000, "hr"),
+        (24 * 60 * 60 * 1_000_000_000, "d")
+    )
+        if round(ns_per_iter / divideby) < 100
+            return @sprintf "%5.2f %2s/it" (ns_per_iter / divideby) unit
+        end
+    end
+    return " >100  d/it"
 end
 
 function showprogress_process_expr(node, metersym)

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -181,7 +181,7 @@ mutable struct ProgressUnknown <: AbstractProgress
     showspeed::Bool         # should the output include average time per iteration
 end
 
-function ProgressUnknown(;dt::Real=0.1, desc::AbstractString="Progress: ", color::Symbol=:green, output::IO=stderr, enabled::Bool = true, showspeed::Bool = true)
+function ProgressUnknown(;dt::Real=0.1, desc::AbstractString="Progress: ", color::Symbol=:green, output::IO=stderr, enabled::Bool = true, showspeed::Bool = false)
     RUNNING_IJULIA_KERNEL[] = running_ijulia_kernel()
     CLEAR_IJULIA[] = clear_ijulia()
     reentrantlocker = Threads.ReentrantLock()
@@ -196,12 +196,12 @@ ProgressUnknown(dt::Real, desc::AbstractString="Progress: ",
 
 ProgressUnknown(desc::AbstractString) = ProgressUnknown(desc=desc)
 
-#...length of percentage and ETA string with days is 29 characters
+#...length of percentage and ETA string with days is 29 characters, speed string is always 14 extra characters
 function tty_width(desc, output, showspeed::Bool)
     full_width = displaysize(output)[2]
     desc_width = length(desc)
     eta_width = 29
-    speed_width = showspeed ? 13 : 0
+    speed_width = showspeed ? 14 : 0
     return max(0, full_width - desc_width - eta_width - speed_width)
 end
 

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -52,7 +52,9 @@ output=stderr, barlen=tty_width(desc), start=0)` creates a progress meter for a
 task with `n` iterations or stages starting from `start`. Output will be
 generated at intervals at least `dt` seconds apart, and perhaps longer if each
 iteration takes longer than `dt`. `desc` is a description of
-the current task.
+the current task. Optionally you can disable the progress bar by setting
+`enable=false`. You can also append a per-iteration average duration like
+"(12.34 ms/it)" to the description by setting `showspeed=true`.
 """
 mutable struct Progress <: AbstractProgress
     n::Int
@@ -110,7 +112,10 @@ color=:green, output=stderr)` creates a progress meter for a task
 which will terminate once a value less than or equal to `thresh` is
 reached. Output will be generated at intervals at least `dt` seconds
 apart, and perhaps longer if each iteration takes longer than
-`dt`. `desc` is a description of the current task.
+`dt`. `desc` is a description of the current task. Optionally you can disable
+the progress meter by setting `enable=false`. You can also append a
+per-iteration average duration like "(12.34 ms/it)" to the description by
+setting `showspeed=true`.
 """
 mutable struct ProgressThresh{T<:Real} <: AbstractProgress
     thresh::T
@@ -162,7 +167,10 @@ color=:green, output=stderr)` creates a progress meter for a task
 which has a non-deterministic termination criterion.
 Output will be generated at intervals at least `dt` seconds
 apart, and perhaps longer if each iteration takes longer than
-`dt`. `desc` is a description of the current task.
+`dt`. `desc` is a description of the current task. Optionally you can disable
+the progress meter by setting `enable=false`. You can also append a
+per-iteration average duration like "(12.34 ms/it)" to the description by
+setting `showspeed=true`.
 """
 mutable struct ProgressUnknown <: AbstractProgress
     done::Bool

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -308,11 +308,11 @@ function updateProgress!(p::ProgressThresh; showvalues = (), truncate_lines = fa
     p.offset = offset
     p.desc = desc
     t = time()
+    elapsed_time = t - p.tinit
     if p.val <= p.thresh && !p.triggered
         p.triggered = true
         if p.printed
             p.triggered = true
-            elapsed_time = t - p.tinit
             dur = durationstring(elapsed_time)
             msg = @sprintf "%s Time: %s (%d iterations)" p.desc dur p.counter
             if p.showspeed

--- a/test/core.jl
+++ b/test/core.jl
@@ -13,6 +13,17 @@
 @test ProgressMeter.Progress(5, "Progress:", Int16(5)).offset == 5
 @test ProgressMeter.ProgressThresh(0.2, "Progress:", Int16(5)).offset == 5
 
+# test speed string formatting
+for ns in [1, 9, 10, 99, 100, 999, 1_000, 9_999, 10_000, 99_000, 100_000, 999_999, 1_000_000, 9_000_000, 10_000_000, 99_999_000, 1_234_567_890, 1_234_567_890 * 10, 1_234_567_890 * 100, 1_234_567_890 * 1_000, 1_234_567_890 * 10_000, 1_234_567_890 * 100_000, 1_234_567_890 * 1_000_000, 1_234_567_890 * 10_000_000]
+    sec = ns / 1_000_000_000
+    try
+        @test length(ProgressMeter.speedstring(sec)) == 11
+    catch
+        @error "ns = $ns caused $(ProgressMeter.speedstring(sec)) (not length 11)"
+        throw()
+    end
+end
+
 # Performance test (from #171)
 function prog_perf(n)
     prog = Progress(n)
@@ -31,6 +42,7 @@ function noprog_perf(n)
     end
     return x
 end
+
 prog_perf(10^7)
 noprog_perf(10^7)
 @time prog_perf(10^7)

--- a/test/test.jl
+++ b/test/test.jl
@@ -346,3 +346,44 @@ end
 
 println("Testing start offset")
 testfunc17()
+
+# speed display option
+function testfunc18A(n, dt, tsleep; start=15)
+    p = ProgressMeter.Progress(n; dt=dt, start=start, showspeed=true)
+    for i in start+1:start+n
+        sleep(tsleep)
+        ProgressMeter.next!(p)
+    end
+end
+
+function testfunc18B(n, dt, tsleep)
+    p = ProgressMeter.ProgressUnknown(n; dt=dt, showspeed=true)
+    for _ in 1:n
+        sleep(tsleep)
+        ProgressMeter.next!(p)
+    end
+    ProgressMeter.finish!(p)
+end
+
+function testfunc18C()
+    p = ProgressMeter.ProgressThresh(1e-5; desc="Minimizing:", showspeed=true)
+    for val in 10 .^ range(2, stop=-6, length=20)
+        ProgressMeter.update!(p, val)
+        sleep(0.1)
+    end
+end
+
+println("Testing speed display")
+testfunc18A(1_000, 0.01, 0.002)
+testfunc18B(1_000, 0.01, 0.002)
+testfunc18C()
+
+function testfunc19()
+    p = ProgressMeter.ProgressThresh(1e-5; desc="Minimizing:", showspeed=true)
+    for val in 10 .^ range(2, stop=-6, length=20)
+        ProgressMeter.update!(p, val; increment=false)
+        sleep(0.1)
+    end
+end
+println("Testing speed display with no update")
+testfunc19()


### PR DESCRIPTION
*I'm pretty new to Julia (both the language and the community), so please help me understand if I'm not following best practices here.*

As someone coming from the Python ecosystem to Julia, one of the things I missed most from my Python workflows was the the functionality of the [tqdm](https://tqdm.github.io/) package. Though ProgressMeter.jl gives me a lot of what I love about tqdm, I really missed being able to see the rate at which my loops are running. Here's an example of the default tqdm output:

100%|███████████████████████████████▉| 8014/8014 [01:37<00:00, 82.29files/s]

So I got to thinking, maybe I can add this functionality, or at least the part of it I miss. And so I dug into the source and did my best to implement a non-invasive default-off `showspeed` option. For simplicity, I chose a fixed-width (11 characters wide) text format to show just the time per iteration speed with at least two digits of precision and no numbers bigger than 100. Here are some examples:

**ProgressUnknown:**
Reading entry: 10 	 Time: 0:00:01 ( 0.11  s/it)
Reading entry: 19 	 Time: 0:00:01 (54.80 ms/it)

**Progress:**
Progress: 100%|███████████████████| Time: 0:00:03 ( 3.19 ms/it)

**ProgressThresh:**
Minimizing: Time: 0:00:01 (18 iterations) (95.67 ms/it)
