### PR TITLE
Base ETA off second iteration onwards for higher accuracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         if: ${{ matrix.version != '0.7' && matrix.version != '1.0' }}
         env:
-          JULIA_NUM_THREADS: 3
+          JULIA_NUM_THREADS: 2
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -59,7 +59,8 @@ mutable struct Progress <: AbstractProgress
     reentrantlocker::Threads.ReentrantLock
     dt::Float64
     counter::Int
-    tfirst::Float64
+    tinit::Float64
+    tsecond::Float64           # ignore the first loop given usually uncharacteristically slow
     tlast::Float64
     printed::Bool              # true if we have issued at least one status update
     desc::String               # prefix to the percentage, e.g.  "Computing..."
@@ -85,9 +86,9 @@ mutable struct Progress <: AbstractProgress
                      )
         reentrantlocker = Threads.ReentrantLock()
         counter = start
-        tfirst = tlast = time()
+        tinit = tsecond = tlast = time()
         printed = false
-        new(n, reentrantlocker, dt, counter, tfirst, tlast, printed, desc, barlen, barglyphs, color, output, offset, 0, start, enabled)
+        new(n, reentrantlocker, dt, counter, tinit, tsecond, tlast, printed, desc, barlen, barglyphs, color, output, offset, 0, start, enabled)
     end
 end
 
@@ -114,7 +115,7 @@ mutable struct ProgressThresh{T<:Real} <: AbstractProgress
     val::T
     counter::Int
     triggered::Bool
-    tfirst::Float64
+    tinit::Float64
     tlast::Float64
     printed::Bool        # true if we have issued at least one status update
     desc::String         # prefix to the percentage, e.g.  "Computing..."
@@ -132,9 +133,9 @@ mutable struct ProgressThresh{T<:Real} <: AbstractProgress
                                offset::Integer=0,
                                enabled = true) where T
         reentrantlocker = Threads.ReentrantLock()
-        tfirst = tlast = time()
+        tinit = tlast = time()
         printed = false
-        new{T}(thresh, reentrantlocker, dt, typemax(T), 0, false, tfirst, tlast, printed, desc, color, output, 0, offset, enabled)
+        new{T}(thresh, reentrantlocker, dt, typemax(T), 0, false, tinit, tlast, printed, desc, color, output, 0, offset, enabled)
     end
 end
 ProgressThresh(thresh::Real; kwargs...) = ProgressThresh{typeof(thresh)}(thresh; kwargs...)
@@ -161,7 +162,7 @@ mutable struct ProgressUnknown <: AbstractProgress
     dt::Float64
     counter::Int
     triggered::Bool
-    tfirst::Float64
+    tinit::Float64
     tlast::Float64
     printed::Bool        # true if we have issued at least one status update
     desc::String         # prefix to the percentage, e.g.  "Computing..."
@@ -173,9 +174,9 @@ end
 
 function ProgressUnknown(;dt::Real=0.1, desc::AbstractString="Progress: ", color::Symbol=:green, output::IO=stderr, enabled::Bool = true)
     reentrantlocker = Threads.ReentrantLock()
-    tfirst = tlast = time()
+    tinit = tlast = time()
     printed = false
-    ProgressUnknown(false, reentrantlocker, dt, 0, false, tfirst, tlast, printed, desc, color, output, 0, enabled)
+    ProgressUnknown(false, reentrantlocker, dt, 0, false, tinit, tlast, printed, desc, color, output, 0, enabled)
 end
 
 ProgressUnknown(dt::Real, desc::AbstractString="Progress: ",
@@ -206,6 +207,9 @@ clear_ijulia() = (IJULIABEHAVIOR[] != IJuliaAppend) && running_ijulia_kernel()
 # update progress display
 function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, valuecolor = :blue, offset::Integer = p.offset, keep = (offset == 0), desc::Union{Nothing,AbstractString} = nothing)
     (!running_ijulia_kernel() & !p.enabled) && return
+    if p.counter == 2 # ignore the first loop given usually uncharacteristically slow
+        p.tsecond = time()
+    end
     if desc !== nothing
         if p.barlen !== nothing
             p.barlen += length(p.desc) - length(desc) #adjust bar length to accommodate new description
@@ -219,7 +223,7 @@ function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, v
             barlen = p.barlen isa Nothing ? tty_width(p.desc, p.output) : p.barlen
             percentage_complete = 100.0 * p.counter / p.n
             bar = barstring(barlen, percentage_complete, barglyphs=p.barglyphs)
-            dur = durationstring(t-p.tfirst)
+            dur = durationstring(t - p.tinit)
             msg = @sprintf "%s%3u%%%s Time: %s" p.desc round(Int, percentage_complete) bar dur
             !clear_ijulia() && print(p.output, "\n" ^ (p.offset + p.numprintedvalues))
             move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
@@ -239,10 +243,10 @@ function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, v
         barlen = p.barlen isa Nothing ? tty_width(p.desc, p.output) : p.barlen
         percentage_complete = 100.0 * p.counter / p.n
         bar = barstring(barlen, percentage_complete, barglyphs=p.barglyphs)
-        elapsed_time = t - p.tfirst
-        est_total_time = elapsed_time * (p.n - p.start) / (p.counter - p.start)
+        elapsed_time = t - p.tsecond # ignore the first loop given usually uncharacteristically slow
+        est_total_time = elapsed_time * (p.n - p.start) / ((p.counter - 1) - p.start)
         if 0 <= est_total_time <= typemax(Int)
-            eta_sec = round(Int, est_total_time - elapsed_time )
+            eta_sec = round(Int, est_total_time - elapsed_time)
             eta = durationstring(eta_sec)
         else
             eta = "N/A"
@@ -272,7 +276,7 @@ function updateProgress!(p::ProgressThresh; showvalues = (), truncate_lines = fa
         p.triggered = true
         if p.printed
             p.triggered = true
-            dur = durationstring(t-p.tfirst)
+            dur = durationstring(t-p.tinit)
             msg = @sprintf "%s Time: %s (%d iterations)" p.desc dur p.counter
             print(p.output, "\n" ^ (p.offset + p.numprintedvalues))
             move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
@@ -289,7 +293,6 @@ function updateProgress!(p::ProgressThresh; showvalues = (), truncate_lines = fa
     end
 
     if t > p.tlast+p.dt && !p.triggered
-        elapsed_time = t - p.tfirst
         msg = @sprintf "%s (thresh = %g, value = %g)" p.desc p.thresh p.val
         print(p.output, "\n" ^ (p.offset + p.numprintedvalues))
         move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
@@ -311,7 +314,7 @@ function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = f
     t = time()
     if p.done
         if p.printed
-            dur = durationstring(t-p.tfirst)
+            dur = durationstring(t-p.tinit)
             msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
             move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
             printover(p.output, msg, p.color)
@@ -323,7 +326,7 @@ function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = f
     end
 
     if t > p.tlast+p.dt
-        dur = durationstring(t-p.tfirst)
+        dur = durationstring(t-p.tinit)
         msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
         move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
         printover(p.output, msg, p.color)
@@ -464,7 +467,7 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p
 end
 
-# Internal method to print additional values below progress bar (lazy-showvalues version) 
+# Internal method to print additional values below progress bar (lazy-showvalues version)
 printvalues!(p::AbstractProgress, showvalues::Function; kwargs...) = printvalues!(p, showvalues(); kwargs...)
 
 function move_cursor_up_while_clearing_lines(io, numlinesup)


### PR DESCRIPTION
Given the first iteration can be slower in julia due to compilation, it appears to be better to to base the ETA timing off the second iteration onwards.

As an example, take this which has a fake 3 second delay after the progress bar init to simulate some compilation of the loop
```julia
n = 100
p = Progress(n)
sleep(3)
for i = 1:n # 5-second loop
    sleep(0.05)
    ProgressMeter.next!(p)
end
```
On master, the first ETA to print starts at about 30 seconds, then gradually reduces linearly throughout, decrementing far faster than seconds in real time and never really giving a fair ETA.

In this PR, the first ETA is 4 seconds, and decrements immediately in-step with real-time seconds towards the final completion of 5 seconds. It never seems inaccurate