### PR TITLE
Only poll IJulia state during init

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -31,7 +31,8 @@ function noprog_perf(n)
     end
     return x
 end
-
-prog_perf(1)
-noprog_perf(1)
+prog_perf(10^7)
+noprog_perf(10^7)
+@time prog_perf(10^7)
+@time noprog_perf(10^7)
 @test @elapsed(prog_perf(10^7)) < 40*@elapsed(noprog_perf(10^7))


### PR DESCRIPTION
`running_ijulia_kernel()` and `clear_ijulia()` are not inexpensive functions, and they're being polled every update.

This changes them to only be polled during creation of the progress meter, then static bools are used in their place for the rest of the run. 

I don't believe this changes any behavior in IJulia?
