### PR TITLE
Improve `finish!` behavior for `Progress`

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -431,9 +431,7 @@ end
 See also `cancel`.
 """
 function finish!(p::Progress; options...)
-    while p.counter < p.n
-        next!(p; options...)
-    end
+    update!(p, p.n; options...)
 end
 
 function finish!(p::ProgressThresh; options...)


### PR DESCRIPTION
When `finish!` is called on a `Progress` type meter with a slow update limit and a significant number of steps left, it will max a CPU core while slowly updating the progress meter until it is complete.

MWE:
```julia
julia> p = Progress(100000000; dt=.1);

julia> next!(p); @time finish!(p)
Progress: 100%|██████████████████████| Time: 0:00:16
 14.919932 seconds (6.75 k allocations: 357.250 KiB)
```

This took me by surprise, and doesn't match the immediate completion behavior specified in the code for the `finish!` methods for `ProgressThresh` and `ProgressUnknown`.

PR:
```julia
julia> p = Progress(100000000; dt=.1);

julia> next!(p); @time finish!(p)
Progress: 100%|██████████████████████| Time: 0:00:01
  0.000068 seconds (43 allocations: 3.422 KiB)
```