### PR TITLE
add spinner option to ProgressUnknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,9 @@ Alternatively, you can display a "spinning ball" symbol
 by passing `spinner=true` to the `ProgressUnknown` constructor.
 ```julia
 prog = ProgressUnknown("Working hard:", spinner=true)
-for val in 1:100
+while true
     ProgressMeter.next!(prog)
-    val%10 == val÷10 == 5 && break
-    sleep(0.1)
+    rand(1:2*10^8) == 42 && break
 end
 ProgressMeter.finish!(prog)
 ```
@@ -235,16 +234,15 @@ use a different character by passing a `spinner` keyword
 to `finish!`, e.g. passing `spinner='✗'` on a failure condition:
 ```julia
 let found=false
-    prog = ProgressUnknown("Working hard:", spinner=true)
-    for val in 1:100
+    prog = ProgressUnknown("Searching for the Answer:", spinner=true)
+    for tries = 1:10^8
         ProgressMeter.next!(prog)
-        if val%10 == val÷10 == 0 # never true for these inputs
+        if rand(1:2*10^8) == 42
             found=true
             break
         end
-        sleep(0.1)
     end
-    ProgressMeter.finish!(prog, spinner = found ? `✓` : '✗')
+    ProgressMeter.finish!(prog, spinner = found ? '✓' : '✗')
 end
 ```
 
@@ -252,11 +250,10 @@ In fact, you can completely customize the spinner character
 by passing a string (or array of characters) to animate as a `spinner`
 argument to `next!`:
 ```julia
-prog = ProgressUnknown("Working hard:", spinner=true)
-for val in 1:100
+prog = ProgressUnknown("Burning the midnight oil:", spinner=true)
+while true
     ProgressMeter.next!(prog, spinner="🌑🌒🌓🌔🌕🌖🌗🌘")
-    val%10 == val÷10 == 5 && break
-    sleep(0.1)
+    rand(1:10^8) == 0xB00 && break
 end
 ProgressMeter.finish!(prog)
 ```

--- a/README.md
+++ b/README.md
@@ -236,16 +236,18 @@ By default, `finish!` changes the spinner to a `✓`, but you can
 use a different character by passing a `spinner` keyword
 to `finish!`, e.g. passing `spinner='✗'` on a failure condition:
 ```julia
-prog = ProgressUnknown("Working hard:", spinner=true)
-for val in 1:100
-    ProgressMeter.next!(prog)
-    if val%10 == val÷10 == 0 # never true for these inputs
-        ProgressMeter.finish!(prog)
-        break
+let found=false
+    prog = ProgressUnknown("Working hard:", spinner=true)
+    for val in 1:100
+        ProgressMeter.next!(prog)
+        if val%10 == val÷10 == 0 # never true for these inputs
+            found=true
+            break
+        end
+        sleep(0.1)
     end
-    sleep(0.1)
+    ProgressMeter.finish!(prog, spinner = found ? `✓` : '✗')
 end
-ProgressMeter.finish!(prog, spinner='✗')
 ```
 
 In fact, you can completely customize the spinner character

--- a/README.md
+++ b/README.md
@@ -219,6 +219,35 @@ for val in ["aaa" , "bb", "c", "d"]
 end
 ```
 
+Alternatively, you can display a "spinning ball" symbol
+by passing `spinner=true` to the `ProgressUnknown` constructor.
+```julia
+prog = ProgressUnknown("Working hard:", spinner=true)
+for val in 1:100
+    ProgressMeter.next!(prog)
+    if val%10 == val÷10 == 5
+        ProgressMeter.finish!(prog)
+        break
+    end
+    sleep(0.1)
+end
+```
+By default, `finish!` changes the spinner to a `✓`, but you can
+use a different character by passing a `spinner_done` keyword
+to `finish!`, e.g. passing `spinner_done='✗'` on a failure condition:
+```julia
+prog = ProgressUnknown("Working hard:", spinner=true)
+for val in 1:100
+    ProgressMeter.next!(prog)
+    if val%10 == val÷10 == 0 # never true for these inputs
+        ProgressMeter.finish!(prog)
+        break
+    end
+    sleep(0.1)
+end
+ProgressMeter.finish!(prog, spinner_done='✗')
+```
+
 ### Printing additional information
 
 You can also print and update information related to the computation by using

--- a/README.md
+++ b/README.md
@@ -225,12 +225,10 @@ by passing `spinner=true` to the `ProgressUnknown` constructor.
 prog = ProgressUnknown("Working hard:", spinner=true)
 for val in 1:100
     ProgressMeter.next!(prog)
-    if val%10 == val÷10 == 5
-        ProgressMeter.finish!(prog)
-        break
-    end
+    val%10 == val÷10 == 5 && break
     sleep(0.1)
 end
+ProgressMeter.finish!(prog)
 ```
 By default, `finish!` changes the spinner to a `✓`, but you can
 use a different character by passing a `spinner` keyword
@@ -257,12 +255,10 @@ argument to `next!`:
 prog = ProgressUnknown("Working hard:", spinner=true)
 for val in 1:100
     ProgressMeter.next!(prog, spinner="🌑🌒🌓🌔🌕🌖🌗🌘")
-    if val%10 == val÷10 == 5
-        ProgressMeter.finish!(prog)
-        break
-    end
+    val%10 == val÷10 == 5 && break
     sleep(0.1)
 end
+ProgressMeter.finish!(prog)
 ```
 (Other interesting-looking spinners include `"⌜⌝⌟⌞"`, `"⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"`, `"▖▘▝▗'"`, and `"▁▂▃▄▅▆▇█"`.)
 

--- a/README.md
+++ b/README.md
@@ -250,8 +250,7 @@ ProgressMeter.finish!(prog, spinner='✗')
 
 In fact, you can completely customize the spinner character
 by passing a string (or array of characters) to animate as a `spinner`
-argument to `next!`, or alternatively a single character
-that you update manually as desired:
+argument to `next!`:
 ```julia
 prog = ProgressUnknown("Working hard:", spinner=true)
 for val in 1:100

--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ for val in 1:100
 end
 ```
 By default, `finish!` changes the spinner to a `✓`, but you can
-use a different character by passing a `spinner_done` keyword
-to `finish!`, e.g. passing `spinner_done='✗'` on a failure condition:
+use a different character by passing a `spinner` keyword
+to `finish!`, e.g. passing `spinner='✗'` on a failure condition:
 ```julia
 prog = ProgressUnknown("Working hard:", spinner=true)
 for val in 1:100
@@ -245,8 +245,25 @@ for val in 1:100
     end
     sleep(0.1)
 end
-ProgressMeter.finish!(prog, spinner_done='✗')
+ProgressMeter.finish!(prog, spinner='✗')
 ```
+
+In fact, you can completely customize the spinner character
+by passing an string (array of characters) to animate as a `spinner`
+argument to `next!`, or alternatively a single character
+that you update manually as desired:
+```julia
+prog = ProgressUnknown("Working hard:", spinner=true)
+for val in 1:100
+    ProgressMeter.next!(prog, spinner="🌑🌒🌓🌔🌕🌖🌗🌘")
+    if val%10 == val÷10 == 5
+        ProgressMeter.finish!(prog)
+        break
+    end
+    sleep(0.1)
+end
+```
+(Other interesting-looking spinners include `"⌜⌝⌟⌞"`, `"⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"`, `"▖▘▝▗'"`, and `"▁▂▃▄▅▆▇█▇▆▅▄▃▂▁"`.)
 
 ### Printing additional information
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ ProgressMeter.finish!(prog, spinner='✗')
 ```
 
 In fact, you can completely customize the spinner character
-by passing an string (array of characters) to animate as a `spinner`
+by passing a string (or array of characters) to animate as a `spinner`
 argument to `next!`, or alternatively a single character
 that you update manually as desired:
 ```julia

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ while true
 end
 ProgressMeter.finish!(prog)
 ```
+
 By default, `finish!` changes the spinner to a `✓`, but you can
 use a different character by passing a `spinner` keyword
 to `finish!`, e.g. passing `spinner='✗'` on a failure condition:

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ for val in 1:100
     sleep(0.1)
 end
 ```
-(Other interesting-looking spinners include `"⌜⌝⌟⌞"`, `"⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"`, `"▖▘▝▗'"`, and `"▁▂▃▄▅▆▇█▇▆▅▄▃▂▁"`.)
+(Other interesting-looking spinners include `"⌜⌝⌟⌞"`, `"⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"`, `"▖▘▝▗'"`, and `"▁▂▃▄▅▆▇█"`.)
 
 ### Printing additional information
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ by passing `spinner=true` to the `ProgressUnknown` constructor.
 prog = ProgressUnknown("Working hard:", spinner=true)
 while true
     ProgressMeter.next!(prog)
-    rand(1:2*10^8) == 42 && break
+    rand(1:2*10^8) == 1 && break
 end
 ProgressMeter.finish!(prog)
 ```

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -176,7 +176,8 @@ apart, and perhaps longer if each iteration takes longer than
 `dt`. `desc` is a description of the current task. Optionally you can disable
 the progress meter by setting `enable=false`. You can also append a
 per-iteration average duration like "(12.34 ms/it)" to the description by
-setting `showspeed=true`.
+setting `showspeed=true`.  Instead of displaying a counter, it
+can optionally display a spinning ball by passing `spinner=true`.
 """
 mutable struct ProgressUnknown <: AbstractProgress
     done::Bool
@@ -189,6 +190,7 @@ mutable struct ProgressUnknown <: AbstractProgress
     printed::Bool           # true if we have issued at least one status update
     desc::String            # prefix to the percentage, e.g.  "Computing..."
     color::Symbol           # default to green
+    spinner::Bool           # show a spinner
     output::IO              # output stream into which the progress is written
     numprintedvalues::Int   # num values printed below progress in last iteration
     enabled::Bool           # is the output enabled
@@ -198,20 +200,20 @@ mutable struct ProgressUnknown <: AbstractProgress
     threads_used::Vector{Int}
 end
 
-function ProgressUnknown(;dt::Real=0.1, desc::AbstractString="Progress: ", color::Symbol=:green, output::IO=stderr, enabled::Bool = true, showspeed::Bool = false)
+function ProgressUnknown(;dt::Real=0.1, desc::AbstractString="Progress: ", color::Symbol=:green, spinner::Bool=false, output::IO=stderr, enabled::Bool = true, showspeed::Bool = false)
     RUNNING_IJULIA_KERNEL[] = running_ijulia_kernel()
     CLEAR_IJULIA[] = clear_ijulia()
     reentrantlocker = Threads.ReentrantLock()
     tinit = tlast = time()
     printed = false
-    ProgressUnknown(false, reentrantlocker, dt, 0, false, tinit, tlast, printed, desc, color, output, 0, enabled, showspeed, 1, 1, Int[])
+    ProgressUnknown(false, reentrantlocker, dt, 0, false, tinit, tlast, printed, desc, color, spinner, output, 0, enabled, showspeed, 1, 1, Int[])
 end
 
 ProgressUnknown(dt::Real, desc::AbstractString="Progress: ",
          color::Symbol=:green, output::IO=stderr; kwargs...) =
     ProgressUnknown(dt=dt, desc=desc, color=color, output=output; kwargs...)
 
-ProgressUnknown(desc::AbstractString) = ProgressUnknown(desc=desc)
+ProgressUnknown(desc::AbstractString; kwargs...) = ProgressUnknown(desc=desc; kwargs...)
 
 #...length of percentage and ETA string with days is 29 characters, speed string is always 14 extra characters
 function tty_width(desc, output, showspeed::Bool)
@@ -385,8 +387,10 @@ function updateProgress!(p::ProgressThresh; showvalues = (), truncate_lines = fa
     end
 end
 
+const spinner_chars = ['◐','◓','◑','◒']
+
 function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = false, valuecolor = :blue, desc = p.desc,
-                        ignore_predictor = false)
+                        ignore_predictor = false, spinner_done::Char = '✓')
     (!RUNNING_IJULIA_KERNEL[] & !p.enabled) && return
     p.desc = desc
     if p.done
@@ -394,7 +398,12 @@ function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = f
             t = time()
             elapsed_time = t - p.tinit
             dur = durationstring(elapsed_time)
-            msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
+            if p.spinner
+                c = p.done ? spinner_done : spinner_chars[p.counter % length(spinner_chars) + 1]
+                msg = @sprintf "%s %c \t Time: %s" p.desc c dur
+            else
+                msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
+            end
             if p.showspeed
                 sec_per_iter = elapsed_time / p.counter
                 msg = @sprintf "%s (%s)" msg speedstring(sec_per_iter)
@@ -414,7 +423,12 @@ function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = f
         end
         if t > p.tlast+p.dt
             dur = durationstring(t-p.tinit)
-            msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
+            if p.spinner
+                c = p.done ? spinner_done : spinner_chars[p.counter % length(spinner_chars) + 1]
+                msg = @sprintf "%s %c \t Time: %s" p.desc c dur
+            else
+                msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
+            end
             if p.showspeed
                 elapsed_time = t - p.tinit
                 sec_per_iter = elapsed_time / p.counter

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -407,8 +407,8 @@ function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = f
             elapsed_time = t - p.tinit
             dur = durationstring(elapsed_time)
             if p.spinner
-                p.spincounter += 1
                 msg = @sprintf "%s %c \t Time: %s" p.desc spinner_char(p, spinner) dur
+                p.spincounter += 1
             else
                 msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
             end
@@ -432,8 +432,8 @@ function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = f
         if t > p.tlast+p.dt
             dur = durationstring(t-p.tinit)
             if p.spinner
-                p.spincounter += 1
                 msg = @sprintf "%s %c \t Time: %s" p.desc spinner_char(p, spinner) dur
+                p.spincounter += 1
             else
                 msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
             end

--- a/test/test.jl
+++ b/test/test.jl
@@ -313,7 +313,22 @@ for _ in 1:10
     ProgressMeter.next!(prog)
     sleep(0.1)
 end
-ProgressMeter.finish!(prog, spinner_done='✗')
+ProgressMeter.finish!(prog, spinner='✗')
+
+myspinner = ['🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘']
+prog = ProgressUnknown("Custom spinner:", spinner=true)
+for val in 1:10
+    ProgressMeter.next!(prog, spinner=myspinner)
+    sleep(0.1)
+end
+ProgressMeter.finish!(prog, spinner='🌞')
+
+prog = ProgressUnknown("Custom spinner:", spinner=true)
+for val in 1:10
+    ProgressMeter.next!(prog, spinner="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+    sleep(0.1)
+end
+ProgressMeter.finish!(prog)
 
 println("Testing fractional bars")
 for front in (['▏','▎','▍','▌','▋','▊', '▉'], ['▁' ,'▂' ,'▃' ,'▄' ,'▅' ,'▆', '▇'], ['░', '▒', '▓',])

--- a/test/test.jl
+++ b/test/test.jl
@@ -301,6 +301,20 @@ for k in 1:2:20
 end
 ProgressMeter.finish!(prog)
 
+prog = ProgressMeter.ProgressUnknown("Reading entry:", spinner=true)
+for _ in 1:10
+    ProgressMeter.next!(prog)
+    sleep(0.1)
+end
+ProgressMeter.finish!(prog)
+
+prog = ProgressMeter.ProgressUnknown("Reading entry:", spinner=true)
+for _ in 1:10
+    ProgressMeter.next!(prog)
+    sleep(0.1)
+end
+ProgressMeter.finish!(prog, spinner_done='✗')
+
 println("Testing fractional bars")
 for front in (['▏','▎','▍','▌','▋','▊', '▉'], ['▁' ,'▂' ,'▃' ,'▄' ,'▅' ,'▆', '▇'], ['░', '▒', '▓',])
     p = ProgressMeter.Progress(100, dt=0.01, barglyphs=ProgressMeter.BarGlyphs('|','█',front,' ','|'), barlen=10)


### PR DESCRIPTION
This adds a `spinner=true` option to the `ProgressUnknown` case, mimicking the one in Pkg (though you can also customize the spinner characters), inspired by [this discourse thread](https://discourse.julialang.org/t/how-to-print-rotating-tick-as-progress-bar-in-terminal/62099).

Closes #92.