### PR TITLE
disable performance tests in github CI

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -47,4 +47,7 @@ prog_perf(10^7)
 noprog_perf(10^7)
 @time prog_perf(10^7)
 @time noprog_perf(10^7)
-@test @elapsed(prog_perf(10^7)) < 9*@elapsed(noprog_perf(10^7))
+
+if get(ENV, "GITHUB_ACTIONS", "false") != "true" # CI environment is too unreliable for performance tests
+    @test @elapsed(prog_perf(10^7)) < 9*@elapsed(noprog_perf(10^7))
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -43,11 +43,10 @@ function noprog_perf(n)
     return x
 end
 
-prog_perf(10^7)
-noprog_perf(10^7)
-@time prog_perf(10^7)
-@time noprog_perf(10^7)
-
-if get(ENV, "GITHUB_ACTIONS", "false") != "true" # CI environment is too unreliable for performance tests
+if get(ENV, "GITHUB_ACTIONS", "false") != "true" # CI environment is too unreliable for performance tests 
+    prog_perf(10^7)
+    noprog_perf(10^7)
+    @time prog_perf(10^7)
+    @time noprog_perf(10^7)
     @test @elapsed(prog_perf(10^7)) < 9*@elapsed(noprog_perf(10^7))
 end


### PR DESCRIPTION
As noted in https://github.com/timholy/ProgressMeter.jl/pull/206#issuecomment-851103843, the github CI machines are too unreliable to do performance comparisons, so this test should be disabled on CI (but still runs when testing locally).