### PR TITLE
Avoid rare NaN in calc_check_iterations

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -244,6 +244,11 @@ running_ijulia_kernel() = isdefined(Main, :IJulia) && Main.IJulia.inited
 clear_ijulia() = (IJULIABEHAVIOR[] != IJuliaAppend) && running_ijulia_kernel()
 
 function calc_check_iterations(p, t)
+    if t == p.tlast
+        # avoid a NaN which could happen because the print time compensation makes an assumption about how long printing
+        # takes, therefore it's possible (but rare) for `t == p.tlast`
+        return p.check_iterations
+    end
     # Adjust the number of iterations that skips time check based on how accurate the last number was
     iterations_per_dt = (p.check_iterations / (t - p.tlast)) * p.dt
     return round(Int, clamp(iterations_per_dt, 1, p.check_iterations * 10))

--- a/test/core.jl
+++ b/test/core.jl
@@ -57,4 +57,4 @@ prog = Progress(10)
 prog.check_iterations = 999
 t = time()
 prog.tlast = t
-@test ProgressMeter.calc_check_iterations(p, t) == 999
+@test ProgressMeter.calc_check_iterations(prog, t) == 999

--- a/test/core.jl
+++ b/test/core.jl
@@ -57,4 +57,4 @@ prog = Progress(10)
 prog.check_iterations = 999
 t = time()
 prog.tlast = t
-@test calc_check_iterations(p, t) == 999
+@test ProgressMeter.calc_check_iterations(p, t) == 999

--- a/test/core.jl
+++ b/test/core.jl
@@ -50,3 +50,11 @@ if get(ENV, "GITHUB_ACTIONS", "false") != "true" # CI environment is too unrelia
     @time noprog_perf(10^7)
     @test @elapsed(prog_perf(10^7)) < 9*@elapsed(noprog_perf(10^7))
 end
+
+# Avoid a NaN due to the estimated print time compensation
+# https://github.com/timholy/ProgressMeter.jl/issues/209
+prog = Progress(10)
+prog.check_iterations = 999
+t = time()
+prog.tlast = t
+@test calc_check_iterations(p, t) == 999


### PR DESCRIPTION
Intended to fix - #209  (will close if confirmed to be fixed in the next release)

Avoids a NaN which could happen because the print time compensation makes an assumption about how long printing takes, therefore it's possible (but rare) for `t == p.tlast` within `calc_check_iterations`