### PR TITLE
put spinner to left of description

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -407,7 +407,7 @@ function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = f
             elapsed_time = t - p.tinit
             dur = durationstring(elapsed_time)
             if p.spinner
-                msg = @sprintf "%s %c \t Time: %s" p.desc spinner_char(p, spinner) dur
+                msg = @sprintf "%c %s \t Time: %s" spinner_char(p, spinner) p.desc dur
                 p.spincounter += 1
             else
                 msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur
@@ -432,7 +432,7 @@ function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = f
         if t > p.tlast+p.dt
             dur = durationstring(t-p.tinit)
             if p.spinner
-                msg = @sprintf "%s %c \t Time: %s" p.desc spinner_char(p, spinner) dur
+                msg = @sprintf "%c %s \t Time: %s" spinner_char(p, spinner) p.desc dur
                 p.spincounter += 1
             else
                 msg = @sprintf "%s %d \t Time: %s" p.desc p.counter dur


### PR DESCRIPTION
I was looking at the Pkg.jl interface again, and I noticed a difference from #206 — it displays the spinner/checkmark to the left of the description, not to the right.

I tried it out in ProgressMeter.jl and it seems to look nicer.  Also, it is nice to be more similar to the Pkg interface.