### PR TITLE
Remove `enabled` dependence on IJulia; fix #214

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -91,7 +91,6 @@ mutable struct Progress <: AbstractProgress
                       enabled::Bool = true,
                       showspeed::Bool = false,
                      )
-        RUNNING_IJULIA_KERNEL[] = running_ijulia_kernel()
         CLEAR_IJULIA[] = clear_ijulia()
         reentrantlocker = Threads.ReentrantLock()
         counter = start
@@ -149,7 +148,6 @@ mutable struct ProgressThresh{T<:Real} <: AbstractProgress
                                offset::Integer=0,
                                enabled = true,
                                showspeed::Bool = false) where T
-        RUNNING_IJULIA_KERNEL[] = running_ijulia_kernel()
         CLEAR_IJULIA[] = clear_ijulia()
         reentrantlocker = Threads.ReentrantLock()
         tinit = tlast = time()
@@ -202,7 +200,6 @@ mutable struct ProgressUnknown <: AbstractProgress
 end
 
 function ProgressUnknown(;dt::Real=0.1, desc::AbstractString="Progress: ", color::Symbol=:green, spinner::Bool=false, output::IO=stderr, enabled::Bool = true, showspeed::Bool = false)
-    RUNNING_IJULIA_KERNEL[] = running_ijulia_kernel()
     CLEAR_IJULIA[] = clear_ijulia()
     reentrantlocker = Threads.ReentrantLock()
     tinit = tlast = time()
@@ -238,7 +235,6 @@ function ijulia_behavior(b)
 end
 
 # Whether or not to use IJulia.clear_output
-const RUNNING_IJULIA_KERNEL = Ref{Bool}(false)
 const CLEAR_IJULIA = Ref{Bool}(false)
 running_ijulia_kernel() = isdefined(Main, :IJulia) && Main.IJulia.inited
 clear_ijulia() = (IJULIABEHAVIOR[] != IJuliaAppend) && running_ijulia_kernel()
@@ -258,7 +254,7 @@ end
 function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, valuecolor = :blue,
                         offset::Integer = p.offset, keep = (offset == 0), desc::Union{Nothing,AbstractString} = nothing,
                         ignore_predictor = false)
-    (!RUNNING_IJULIA_KERNEL[] & !p.enabled) && return
+    !p.enabled && return
     if p.counter == 2 # ignore the first loop given usually uncharacteristically slow
         p.tsecond = time()
     end
@@ -336,7 +332,7 @@ end
 
 function updateProgress!(p::ProgressThresh; showvalues = (), truncate_lines = false, valuecolor = :blue,
                         offset::Integer = p.offset, keep = (offset == 0), desc = p.desc, ignore_predictor = false)
-    (!RUNNING_IJULIA_KERNEL[] & !p.enabled) && return
+    !p.enabled && return
     p.offset = offset
     p.desc = desc
     if p.val <= p.thresh && !p.triggered
@@ -404,7 +400,7 @@ spinner_char(p::ProgressUnknown, spinner::AbstractString) =
 
 function updateProgress!(p::ProgressUnknown; showvalues = (), truncate_lines = false, valuecolor = :blue, desc = p.desc,
                         ignore_predictor = false, spinner::Union{AbstractChar,AbstractString,AbstractVector{<:AbstractChar}} = spinner_chars)
-    (!RUNNING_IJULIA_KERNEL[] & !p.enabled) && return
+    !p.enabled && return
     p.desc = desc
     if p.done
         if p.printed


### PR DESCRIPTION
It doesn't make sense to me that `enabled` stops working as expected in IJulia (ie Progress will always updates/prints in IJulia, regardless of `enabled` value).

Fixes #214 