### PR TITLE
Progressmeter for output to file

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -257,7 +257,7 @@ end
 # update progress display
 function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, valuecolor = :blue,
                         offset::Integer = p.offset, keep = (offset == 0), desc::Union{Nothing,AbstractString} = nothing,
-                        ignore_predictor = false)
+                        ignore_predictor = false, keepall=false)
     (!RUNNING_IJULIA_KERNEL[] & !p.enabled) && return
     if p.counter == 2 # ignore the first loop given usually uncharacteristically slow
         p.tsecond = time()
@@ -321,7 +321,11 @@ function updateProgress!(p::Progress; showvalues = (), truncate_lines = false, v
             move_cursor_up_while_clearing_lines(p.output, p.numprintedvalues)
             printover(p.output, msg, p.color)
             printvalues!(p, showvalues; color = valuecolor, truncate = truncate_lines)
-            !CLEAR_IJULIA[] && print(p.output, "\r\u1b[A" ^ (p.offset + p.numprintedvalues))
+            if keepall
+                println(p.output)
+            else
+                !CLEAR_IJULIA[] && print(p.output, "\r\u1b[A" ^ (p.offset + p.numprintedvalues))
+            end
             flush(p.output)
             # Compensate for any overhead of printing. This can be
             # especially important if you're running over a slow network


### PR DESCRIPTION
this is could be an alternative to #222 
this is based on what is already done for the `keep` keyword

set `keepall=true` in `next!` or `update!` for it to take effect (only for `Progress` right now, but it can easily be adapted to `ProgressTresh` and `ProgressUnknown`)

```julia-repl
julia> io = IOBuffer()
       p = Progress(5, output=io)
       for i in 1:5
       sleep(0.2)
       next!(p, keepall=true, showvalues=[(:i,i),(:x,sin(i))])
       end
       print(String(take!(io)))

Progress:  40%|█████████████████                        |  ETA: 0:00:01
  i:  2
  x:  0.9092974268256817
Progress:  60%|█████████████████████████                |  ETA: 0:00:00
  i:  3
  x:  0.1411200080598672
Progress:  80%|█████████████████████████████████        |  ETA: 0:00:00
  i:  4
  x:  -0.7568024953079282
Progress: 100%|█████████████████████████████████████████| Time: 0:00:01
  i:  5
  x:  -0.9589242746631385
```

if there are still escape characters in the output for the color, you can wrap the io in `IOContext(io, :color => false)`