### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Threads.@threads for i in 1:10
     sleep(2*rand())
     next!(p)
 end
+finish!(p)
 ```
 
 ```julia
@@ -120,6 +121,7 @@ for i in 1:n
     end
 end
 wait.(tasks)
+finish!(p)
 ```
 
 ### Progress bar style


### PR DESCRIPTION
Added a 
```julia
finish!(p)
```
to the threaded examples. In my experience at least, some threaded loops do not print the total time, only the last iteration. 
While I'm sure this is not trye in all threaded cases, it seems more prudent to add this to the documentation.