### PR TITLE
fix multi-line string in showvalues

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -583,6 +583,13 @@ function finish!(p::ProgressUnknown; options...)
     end
 end
 
+function replace_EOL_with_space(s)
+    width = displaysize(stdout)[2]
+    lines = split(s, "\n")
+    filled = lines .* " ".^(width .- sizeof.(lines))
+    return join(filled)
+end
+
 # Internal method to print additional values below progress bar
 function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate = false)
     length(showvalues) == 0 && return
@@ -591,7 +598,7 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        msg = "\n  " * rpad(string(name) * ": ", maxwidth+2+1) * string(value)
+        msg = "\n  " * rpad(string(name) * ": ", maxwidth+2+1) * replace_EOL_with_space(string(value))
         max_len = (displaysize(p.output)::Tuple{Int,Int})[2]
         # I don't understand why the minus 1 is necessary here, but empircally
         # it is needed.

--- a/test/test_showvalues.jl
+++ b/test/test_showvalues.jl
@@ -111,4 +111,12 @@ for i in 1:50
     sleep(0.1)
 end
 
+println("Testing multi-line string")
+p = ProgressMeter.Progress(10)
+for iter in 1:10
+    sleep(0.1)
+    s = "line 1\nline 2\nline 3"
+    next!(p; showvalues = [("lines", s)])
+end
+
 end # if


### PR DESCRIPTION
Fix https://github.com/timholy/ProgressMeter.jl/issues/224?notification_referrer_id=NT_kwDOAdnnorMyNjY0Nzk3OTgzOjMxMDU3ODI2#issuecomment-1370681492

However, I cannot figure out why there is one additional blank line while displaying `Dict`:
```julia
p = ProgressMeter.Progress(10)
for iter in 1:10
    sleep(0.1)
    next!(p; showvalues = Dict(:1 => 1, :halfdone => (1 >= 50/2)))
end
```
![image](https://user-images.githubusercontent.com/31057826/210532490-468930bb-89c8-403b-9044-f6b9fbb8bcdb.png)
