### PR TITLE
Deprecate non-kwargs methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can also control progress updates and reports manually:
 ```julia
 function my_long_running_function(filenames::Array)
     n = length(filenames)
-    p = Progress(n, dt=1.0)   # minimum update interval: 1 second
+    p = Progress(n; dt=1.0)   # minimum update interval: 1 second
     for f in filenames
         # Here's where you do all the hard, slow work
         next!(p)
@@ -86,7 +86,7 @@ function readFileLines(fileName::String)
     fileSize = position(file)
 
     seekstart(file)
-    p = Progress(fileSize, dt=1.0)   # minimum update interval: 1 second
+    p = Progress(fileSize; dt=1.0)   # minimum update interval: 1 second
     while !eof(file)
         line = readline(file)
         # Here's where you do all the hard, slow work
@@ -130,7 +130,7 @@ Optionally, a description string can be specified which will be prepended to the
 and a progress meter `M` characters long can be shown.  E.g.
 
 ```julia
-p = Progress(n, "Computing initial pass...", 50)
+p = Progress(n; desc="Computing initial pass...")
 ```
 
 will yield
@@ -146,7 +146,7 @@ specified by passing a `BarGlyphs` object as the keyword argument `barglyphs`. T
 constructor can either take 5 characters as arguments or a single 5 character string. E.g.
 
 ```julia
-p = Progress(n, dt=0.5, barglyphs=BarGlyphs("[=> ]"), barlen=50, color=:yellow)
+p = Progress(n; dt=0.5, barglyphs=BarGlyphs("[=> ]"), barlen=50, color=:yellow)
 ```
 
 will yield
@@ -159,7 +159,7 @@ It is possible to give a vector of characters that acts like a transition betwee
 character and the fully filled character. For example, definining the progress bar as:
 
 ```julia
-p = Progress(n, dt=0.5,
+p = Progress(n; dt=0.5,
              barglyphs=BarGlyphs('|','█', ['▁' ,'▂' ,'▃' ,'▄' ,'▅' ,'▆', '▇'],' ','|',),
              barlen=10)
 ```
@@ -179,9 +179,9 @@ example to achieve convergence within a specified tolerance.  In such
 circumstances, you can use the `ProgressThresh` type:
 
 ```julia
-prog = ProgressThresh(1e-5, "Minimizing:")
+prog = ProgressThresh(1e-5; desc="Minimizing:")
 for val in exp10.(range(2, stop=-6, length=20))
-    ProgressMeter.update!(prog, val)
+    update!(prog, val)
     sleep(0.1)
 end
 ```
@@ -192,11 +192,11 @@ Some tasks only terminate when some non-deterministic criterion is satisfied. In
 circumstances, you can use the `ProgressUnknown` type:
 
 ```julia
-prog = ProgressUnknown("Titles read:")
+prog = ProgressUnknown(desc="Titles read:")
 for val in ["a" , "b", "c", "d"]
-    ProgressMeter.next!(prog)
+    next!(prog)
     if val == "c"
-        ProgressMeter.finish!(prog)
+        finish!(prog)
         break
     end
     sleep(0.1)
@@ -208,13 +208,13 @@ This will display the number of calls to `next!` until `finish!` is called.
 If your counter does not monotonically increases, you can also set the counter by hand.
 
 ```julia
-prog = ProgressUnknown("Total length of characters read:")
+prog = ProgressUnknown(desc="Total length of characters read:")
 total_length_characters = 0
 for val in ["aaa" , "bb", "c", "d"]
     global total_length_characters += length(val)
-    ProgressMeter.update!(prog, total_length_characters)
+    update!(prog, total_length_characters)
     if val == "c"
-        ProgressMeter.finish!(prog)
+        finish!(prog)
         break
     end
     sleep(0.5)
@@ -224,9 +224,9 @@ end
 Alternatively, you can display a "spinning ball" symbol
 by passing `spinner=true` to the `ProgressUnknown` constructor.
 ```julia
-prog = ProgressUnknown("Working hard:", spinner=true)
+prog = ProgressUnknown(desc="Working hard:", spinner=true)
 while true
-    ProgressMeter.next!(prog)
+    next!(prog)
     rand(1:2*10^8) == 1 && break
 end
 ProgressMeter.finish!(prog)
@@ -237,15 +237,15 @@ use a different character by passing a `spinner` keyword
 to `finish!`, e.g. passing `spinner='✗'` on a failure condition:
 ```julia
 let found=false
-    prog = ProgressUnknown("Searching for the Answer:", spinner=true)
-    for tries = 1:10^8
-        ProgressMeter.next!(prog)
+    prog = ProgressUnknown(desc="Searching for the Answer:", spinner=true)
+    for tries in 1:10^8
+        next!(prog)
         if rand(1:2*10^8) == 42
             found=true
             break
         end
     end
-    ProgressMeter.finish!(prog, spinner = found ? '✓' : '✗')
+    finish!(prog, spinner = found ? '✓' : '✗')
 end
 ```
 
@@ -253,12 +253,12 @@ In fact, you can completely customize the spinner character
 by passing a string (or array of characters) to animate as a `spinner`
 argument to `next!`:
 ```julia
-prog = ProgressUnknown("Burning the midnight oil:", spinner=true)
+prog = ProgressUnknown(desc="Burning the midnight oil:", spinner=true)
 while true
-    ProgressMeter.next!(prog, spinner="🌑🌒🌓🌔🌕🌖🌗🌘")
+    next!(prog, spinner="🌑🌒🌓🌔🌕🌖🌗🌘")
     rand(1:10^8) == 0xB00 && break
 end
-ProgressMeter.finish!(prog)
+finish!(prog)
 ```
 (Other interesting-looking spinners include `"⌜⌝⌟⌞"`, `"⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"`, `"🕐🕑🕒🕓🕔🕕🕖🕗🕘🕙🕚🕛"`, `"▖▘▝▗'"`, and `"▁▂▃▄▅▆▇█"`.)
 
@@ -271,10 +271,10 @@ and the value of a dummy variable `x` below the progress meter:
 ```julia
 x,n = 1,10
 p = Progress(n)
-for iter = 1:10
+for iter in 1:10
     x *= 2
     sleep(0.5)
-    ProgressMeter.next!(p; showvalues = [(:iter,iter), (:x,x)])
+    next!(p; showvalues = [(:iter,iter), (:x,x)])
 end
 ```
 
@@ -286,11 +286,11 @@ you can alternatively pass a zero-argument function as a callback to the `showva
 x,n = 1,10
 p = Progress(n)
 generate_showvalues(iter, x) = () -> [(:iter,iter), (:x,x)]
-for iter = 1:10
+for iter in 1:10
     x *= 2
     sleep(0.5)
 # unlike `showvalues=generate_showvalues(iter, x)()`, this version only evaluate the function when necessary
-ProgressMeter.next!(p; showvalues = generate_showvalues(iter, x))
+next!(p; showvalues = generate_showvalues(iter, x))
 end
 ```
 
@@ -303,10 +303,10 @@ when constructing a `Progress`, `ProgressUnknown`, or `ProgressThresh`.
 ```julia
 x,n = 1,10
 p = Progress(n; showspeed=true)
-for iter = 1:10
+for iter in 1:10
     x *= 2
     sleep(0.5)
-    ProgressMeter.next!(p; showvalues = [(:iter,iter), (:x,x)])
+    next!(p; showvalues = [(:iter,iter), (:x,x)])
 end
 ```
 
@@ -371,7 +371,7 @@ using Distributed
 
 n_steps = 20
 p = Progress(n_steps)
-channel = RemoteChannel(()->Channel{Bool}(), 1)
+channel = RemoteChannel(() -> Channel{Bool}(), 1)
 
 # introduce a long-running dummy task to all workers
 @everywhere long_task() = sum([ 1/x for x in 1:100_000_000 ])
@@ -418,7 +418,7 @@ It possible to disable the progress meter when the use is optional.
 ```julia
 x,n = 1,10
 p = Progress(n; enabled = false)
-for iter = 1:10
+for iter in 1:10
     x *= 2
     sleep(0.5)
     ProgressMeter.next!(p)

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -798,7 +798,7 @@ function showprogressdistributed(args...)
 
     setup = quote
         n = length($(esc(r)))
-        p = Progress(n, $(showprogress_process_args(progressargs)...)) #? kwargs?
+        p = Progress(n, $(showprogress_process_args(progressargs)...))
         ch = RemoteChannel(() -> Channel{Bool}(n))
     end
 
@@ -842,16 +842,15 @@ end
 
 """
 ```
-@showprogress dt "Computing..." for i = 1:50
+@showprogress [desc="Computing..."] for i = 1:50
     # computation goes here
 end
 
-@showprogress dt "Computing..." pmap(x->x^2, 1:50)
+@showprogress [desc="Computing..."] pmap(x->x^2, 1:50)
 ```
-displays progress in performing a computation. `dt` is the minimum
-interval in seconds between updates to the user. You may optionally 
+displays progress in performing a computation.  You may optionally 
 supply a custom message to be printed that specifies the computation 
-being performed.
+being performed or other options.
 
 `@showprogress` works for loops, comprehensions, map, reduce, and pmap.
 """
@@ -946,7 +945,7 @@ function showprogress(args...)
 
         setup = quote
             iterable = $(esc(obj))
-            $(esc(metersym)) = Progress(length(iterable), $(showprogress_process_args(progressargs)...)) #? kwargs?
+            $(esc(metersym)) = Progress(length(iterable), $(showprogress_process_args(progressargs)...))
         end
 
         if expr.head === :for
@@ -996,7 +995,7 @@ function showprogress(args...)
 
         # create appropriate Progress expression
         lenex = :(ncalls($(esc(mapfun)), ($([esc(a) for a in mapargs]...),)))
-        progex = :(Progress($lenex, $([esc(a) for a in progressargs]...)))
+        progex = :(Progress($lenex, $(showprogress_process_args(progressargs)...)))
 
         # insert progress and mapfun kwargs
         push!(call.args, Expr(:kw, :progress, progex))
@@ -1064,29 +1063,6 @@ function ncalls(mapfun::Function, map_args)
     end
 end
 
-# Deprecated legacy constructor calls
-
-@deprecate Progress(n::Integer, dt::Real, desc::AbstractString="Progress: ",
-    barlen=nothing, color::Symbol=:green, output::IO=stderr;
-    offset::Integer=0) Progress(n; dt=dt, desc=desc, barlen=barlen, color=color, output=output, offset=offset)
-
-@deprecate Progress(n::Integer, desc::AbstractString, offset::Integer=0; kwargs...) Progress(n; desc=desc, offset=offset, kwargs...)
-
-@deprecate ProgressThresh(thresh::Real, dt::Real, desc::AbstractString="Progress: ",
-         color::Symbol=:green, output::IO=stderr;
-         offset::Integer=0) ProgressThresh(thresh; dt=dt, desc=desc, color=color, output=output, offset=offset)
-
-@deprecate ProgressThresh(thresh::Real, desc::AbstractString, offset::Integer=0) ProgressThresh(thresh; desc=desc, offset=offset)
-
-@deprecate ProgressUnknown(dt::Real, desc::AbstractString="Progress: ",
-         color::Symbol=:green, output::IO=stderr; kwargs...) ProgressUnknown(; dt=dt, desc=desc, color=color, output=output, kwargs...)
-
-@deprecate ProgressUnknown(desc::AbstractString; kwargs...) ProgressUnknown(; desc=desc, kwargs...)
-
-@deprecate next!(p::Union{Progress, ProgressUnknown}, color::Symbol; options...) next!(p; color=color, options...)
-
-@deprecate update!(p::AbstractProgress, val, color; options...) update!(p, val; color=color, options...)
-
-@deprecate cancel(p::AbstractProgress, msg, color; options...) cancel(p, msg; color=color, options...)
+include("deprecated.jl")
 
 end

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -243,7 +243,7 @@ function updateProgress!(p::Progress; showvalues = (),
                          truncate_lines = false, valuecolor = :blue,
                          offset::Integer = p.offset, keep = (offset == 0), 
                          desc::Union{Nothing,AbstractString} = nothing,
-                         ignore_predictor = false, color = p.color)
+                         ignore_predictor = false, color = p.color, max_steps = p.n)
     !p.enabled && return
     if p.counter == 2 # ignore the first loop given usually uncharacteristically slow
         p.tsecond = time()
@@ -256,6 +256,7 @@ function updateProgress!(p::Progress; showvalues = (),
     end
     p.offset = offset
     p.color = color
+    p.n = max_steps
     if p.counter >= p.n
         if p.counter == p.n && p.printed
             t = time()
@@ -327,9 +328,10 @@ function updateProgress!(p::ProgressThresh; showvalues = (),
                          truncate_lines = false, valuecolor = :blue,
                          offset::Integer = p.offset, keep = (offset == 0), 
                          desc = p.desc, ignore_predictor = false,
-                         color = p.color)
+                         color = p.color, thresh = p.thresh)
     !p.enabled && return
     p.offset = offset
+    p.thresh = thresh
     p.color = color
     p.desc = desc
     if p.val <= p.thresh && !p.triggered

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,22 @@
+@deprecate Progress(n::Integer, dt::Real, desc::AbstractString="Progress: ",
+    barlen=nothing, color::Symbol=:green, output::IO=stderr;
+    offset::Integer=0) Progress(n; dt=dt, desc=desc, barlen=barlen, color=color, output=output, offset=offset)
+
+@deprecate Progress(n::Integer, desc::AbstractString, offset::Integer=0; kwargs...) Progress(n; desc=desc, offset=offset, kwargs...)
+
+@deprecate ProgressThresh(thresh::Real, dt::Real, desc::AbstractString="Progress: ",
+         color::Symbol=:green, output::IO=stderr;
+         offset::Integer=0) ProgressThresh(thresh; dt=dt, desc=desc, color=color, output=output, offset=offset)
+
+@deprecate ProgressThresh(thresh::Real, desc::AbstractString, offset::Integer=0) ProgressThresh(thresh; desc=desc, offset=offset)
+
+@deprecate ProgressUnknown(dt::Real, desc::AbstractString="Progress: ",
+         color::Symbol=:green, output::IO=stderr; kwargs...) ProgressUnknown(; dt=dt, desc=desc, color=color, output=output, kwargs...)
+
+@deprecate ProgressUnknown(desc::AbstractString; kwargs...) ProgressUnknown(; desc=desc, kwargs...)
+
+@deprecate next!(p::Union{Progress, ProgressUnknown}, color::Symbol; options...) next!(p; color=color, options...)
+
+@deprecate update!(p::AbstractProgress, val, color; options...) update!(p, val; color=color, options...)
+
+@deprecate cancel(p::AbstractProgress, msg, color; options...) cancel(p, msg; color=color, options...)

--- a/test/core.jl
+++ b/test/core.jl
@@ -10,8 +10,8 @@
 @test ProgressMeter.durationstring(60*60*24*10 - 0.1) == "9 days, 23:59:59"
 @test ProgressMeter.durationstring(60*60*24*10) == "10.00 days"
 
-@test ProgressMeter.Progress(5, "Progress:", Int16(5)).offset == 5
-@test ProgressMeter.ProgressThresh(0.2, "Progress:", Int16(5)).offset == 5
+@test ProgressMeter.Progress(5, desc="Progress:", offset=Int16(5)).offset == 5
+@test ProgressMeter.ProgressThresh(0.2, desc="Progress:", offset=Int16(5)).offset == 5
 
 # test speed string formatting
 for ns in [1, 9, 10, 99, 100, 999, 1_000, 9_999, 10_000, 99_000, 100_000, 999_999, 1_000_000, 9_000_000, 10_000_000, 99_999_000, 1_234_567_890, 1_234_567_890 * 10, 1_234_567_890 * 100, 1_234_567_890 * 1_000, 1_234_567_890 * 10_000, 1_234_567_890 * 100_000, 1_234_567_890 * 1_000_000, 1_234_567_890 * 10_000_000]

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,92 @@
+println("Testing deprecated @showprogress syntax")
+
+# positional arguments
+@test_deprecated @showprogress 0.01 "Red:" 40 :red stderr for i=1:15
+    sleep(0.1)
+end
+# mixed cases
+@test_deprecated @showprogress "Blue: " color=:blue for i=1:10
+    sleep(0.1)
+end
+@test_deprecated @showprogress color=:yellow "Yellow: " showspeed=true for i=1:10
+    sleep(0.1)
+end
+@test_deprecated @showprogress "Invisible: " enabled=false for i=1:10
+    sleep(0.1)
+end
+
+@test_deprecated @showprogress 0.05 "Red:" 40 :red stderr map(x->(sleep(0.01);x^2), 1:100)
+@test_deprecated @showprogress color=:yellow "Yellow: " showspeed=true map(x->(sleep(0.01);x^2), 1:100)
+@test_deprecated @showprogress "Invisible: " enabled=false map(x->(sleep(0.01);x^2), 1:100)
+
+println("Testing deprecated Progress building")
+
+@test_deprecated begin
+    local p = Progress(10, 23, "ABC", 47, :red, stdout)
+    @test p.n == 10
+    @test p.dt == 23
+    @test p.desc == "ABC"
+    @test p.barlen == 47
+    @test p.color == :red
+    @test p.output == stdout
+end
+
+@test_deprecated begin
+    local p = Progress(10, "ABC", 23)
+    @test p.n == 10
+    @test p.desc == "ABC"
+    @test p.offset == 23
+end
+
+@test_deprecated begin 
+    local p = ProgressThresh(0.1, 23, "ABC", :red, stdout)
+    @test p.thresh == 0.1
+    @test p.dt == 23
+    @test p.desc == "ABC"
+    @test p.color == :red
+    @test p.output == stdout
+end
+
+@test_deprecated begin
+    local p = ProgressThresh(0.1, "ABC", 23)
+    @test p.thresh == 0.1
+    @test p.desc == "ABC"
+    @test p.offset == 23
+end
+
+@test_deprecated begin 
+    local p = ProgressUnknown(23, "ABC", :red, stdout)
+    @test p.dt == 23
+    @test p.desc == "ABC"
+    @test p.color == :red
+    @test p.output == stdout
+end
+
+@test_deprecated begin
+    local p = ProgressUnknown("ABC")
+    @test p.desc == "ABC"
+end
+
+println("Testing deprecated updating")
+
+p = Progress(10; dt=0)
+next!(p)
+@test_deprecated next!(p, :red)
+sleep(0.5)
+@test_deprecated update!(p, 5, :blue)
+sleep(0.5)
+@test_deprecated cancel(p, "Oops!", :green)
+
+p = ProgressUnknown(dt=0)
+next!(p)
+@test_deprecated next!(p, :red)
+sleep(0.5)
+@test_deprecated update!(p, 5, :blue)
+sleep(0.5)
+@test_deprecated cancel(p, "Oops!", :green)
+
+p = ProgressThresh(0.1; dt=0)
+update!(p, 0.9)
+@test_deprecated update!(p, 0.5, :blue)
+sleep(0.5)
+@test_deprecated cancel(p, "Oops!", :green)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,6 @@ end
 @testset "Threading" begin
     include("test_threads.jl")
 end
-
+@testset "Deprecated" begin
+    include("deprecated.jl")
+end

--- a/test/test.jl
+++ b/test/test.jl
@@ -3,7 +3,7 @@ using Random: seed!
 seed!(123)
 
 function testfunc(n, dt, tsleep)
-    p = ProgressMeter.Progress(n, dt)
+    p = ProgressMeter.Progress(n; dt=dt)
     for i = 1:n
         sleep(tsleep)
         ProgressMeter.next!(p)
@@ -14,7 +14,7 @@ testfunc(107, 0.01, 0.01)
 
 
 function testfunc2(n, dt, tsleep, desc, barlen)
-    p = ProgressMeter.Progress(n, dt, desc, barlen)
+    p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen)
     for i = 1:n
         sleep(tsleep)
         ProgressMeter.next!(p)
@@ -27,7 +27,7 @@ testfunc2(107, 0.01, 0.01, "", 0)
 
 
 function testfunc3(n, tsleep, desc)
-    p = ProgressMeter.Progress(n, desc)
+    p = ProgressMeter.Progress(n; desc=desc)
     for i = 1:n
         sleep(tsleep)
         ProgressMeter.next!(p)
@@ -42,7 +42,7 @@ testfunc3(107, 0.02, "")
 
 
 function testfunc4()  # test "days" format
-    p = ProgressMeter.Progress(10000000, "Test...")
+    p = ProgressMeter.Progress(10000000, desc="Test...")
     for i = 1:105
         sleep(0.02)
         ProgressMeter.next!(p)
@@ -53,14 +53,14 @@ println("Testing that not even 1% required...")
 testfunc4()
 
 function testfunc5A(n, dt, tsleep, desc, barlen)
-    p = ProgressMeter.Progress(n, dt, desc, barlen)
+    p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen)
     for i = 1:round(Int, floor(n/2))
         sleep(tsleep)
         ProgressMeter.next!(p)
     end
     for i = round(Int, ceil(n/2)):n
         sleep(tsleep)
-        ProgressMeter.next!(p, :red)
+        ProgressMeter.next!(p; color=:red)
     end
 end
 
@@ -68,7 +68,7 @@ println("\nTesting changing the bar color")
 testfunc5A(107, 0.01, 0.01, "Computing...", 50)
 
 function testfunc5B(n, dt, tsleep, desc, barlen)
-    p = ProgressMeter.Progress(n, dt, desc, barlen)
+    p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen)
     for i = 1:n
         sleep(tsleep)
         ProgressMeter.next!(p)
@@ -80,11 +80,11 @@ function testfunc5B(n, dt, tsleep, desc, barlen)
 end
 
 println("\nTesting changing the description")
-testfunc5B(107, 0.01, 0.05, "Step 1...", 50)
+testfunc5B(107, 0.01, 0.02, "Step 1...", 50)
 
 
 function testfunc6(n, dt, tsleep)
-    ProgressMeter.@showprogress dt for i in 1:n
+    ProgressMeter.@showprogress dt=dt for i in 1:n
         if i == div(n, 2)
             break
         end
@@ -96,7 +96,7 @@ function testfunc6(n, dt, tsleep)
 end
 
 function testfunc6a(n, dt, tsleep)
-    ProgressMeter.@showprogress dt for i in 1:n, j in 1:n
+    ProgressMeter.@showprogress dt=dt for i in 1:n, j in 1:n
         if i == div(n, 2)
             break
         end
@@ -113,12 +113,12 @@ testfunc6a(30, 0.01, 0.002)
 
 
 function testfunc7(n, dt, tsleep)
-    s = ProgressMeter.@showprogress dt "Calculating..." [(sleep(tsleep); z) for z in 1:n]
+    s = ProgressMeter.@showprogress dt=dt desc="Calculating..." [(sleep(tsleep); z) for z in 1:n]
     @test s == [1:n;]
 end
 
 function testfunc7a(n, dt, tsleep)
-    s = ProgressMeter.@showprogress dt "Calculating..." [(sleep(tsleep); z) for z in 1:n, y in 1:n]
+    s = ProgressMeter.@showprogress dt=dt desc="Calculating..." [(sleep(tsleep); z) for z in 1:n, y in 1:n]
     @test s == [z for z in 1:n, y in 1:n]
 end
 
@@ -128,7 +128,7 @@ testfunc7a(5, 0.1, 0.1)
 
 
 function testfunc8(n, dt, tsleep)
-    ProgressMeter.@showprogress dt for i in 1:n
+    ProgressMeter.@showprogress dt=dt for i in 1:n
         if rand() < 0.7
             sleep(tsleep)
             continue
@@ -148,16 +148,16 @@ function testfunc8(n, dt, tsleep)
 end
 
 println("Testing @showprogress macro on a for loop with inner loops containing continue and break statements")
-testfunc8(3000, 0.01, 0.002)
+testfunc8(3000, 0.01, 0.001)
 
 
 function testfunc9(n, dt, tsleep)
-    s = ProgressMeter.@showprogress dt "Calculating..." Float64[(sleep(tsleep); z) for z in 1:n]
+    s = ProgressMeter.@showprogress dt=dt desc="Calculating..." Float64[(sleep(tsleep); z) for z in 1:n]
     @test s == [1:n;]
 end
 
 function testfunc9a(n, dt, tsleep)
-    s = ProgressMeter.@showprogress dt "Calculating..." Float64[(sleep(tsleep); z) for z in 1:n, y in 1:n]
+    s = ProgressMeter.@showprogress dt=dt desc="Calculating..." Float64[(sleep(tsleep); z) for z in 1:n, y in 1:n]
     @test s == [z for z in 1:n, y in 1:n]
 end
 
@@ -167,7 +167,7 @@ testfunc9a(10, 0.1, 0.01)
 
 
 function testfunc10(n, k, dt, tsleep)
-    p = ProgressMeter.Progress(n, dt)
+    p = ProgressMeter.Progress(n; dt=dt)
     for i = 1:k
         sleep(tsleep)
         ProgressMeter.next!(p)
@@ -180,7 +180,7 @@ println("Testing over-shooting progress with finish!...")
 testfunc10(107, 111, 0.01, 0.01)
 
 function testfunc11(n, dt, tsleep)
-    p = ProgressMeter.Progress(n, dt)
+    p = ProgressMeter.Progress(n, dt=dt)
     for i = 1:n÷2
         sleep(tsleep)
         ProgressMeter.next!(p)
@@ -196,7 +196,7 @@ println("Testing update! to 0...")
 testfunc11(6, 0.01, 0.3)
 
 function testfunc13()
-    ProgressMeter.@showprogress 1 for i=1:10
+    ProgressMeter.@showprogress dt=1 for i=1:10
         return
     end
 end
@@ -204,68 +204,54 @@ end
 println("Testing @showprogress macro on loop ending with return statement")
 testfunc13()
 
-function testfunc13()
+function testfunc13a()
     n = 30
     # no keyword arguments
     p = ProgressMeter.Progress(n)
     for i in 1:n
-        sleep(0.1)
+        sleep(0.05)
         ProgressMeter.next!(p)
     end
     # full keyword arguments
     start = 15
-    p = ProgressMeter.Progress(n, dt=0.01, desc="", color=:red, output=stderr, barlen=40, start = start)
+    p = ProgressMeter.Progress(n; dt=0.01, desc="", color=:red, output=stderr, barlen=40, start = start)
     for i in 1:n-start
-        sleep(0.1)
+        sleep(0.05)
         ProgressMeter.next!(p)
     end
 end
 
-function testfunc13a()
-    # positional arguments
-    @showprogress 0.01 "Red:" 40 :red stderr for i=1:15
-        sleep(0.1)
-    end
+function testfunc13b()
     # same with keyword arguments only
     @showprogress dt=0.01 color=:red output=stderr barlen=40 for i=1:15
-        sleep(0.1)
-    end
-    # mixed cases
-    @showprogress "Blue: " color=:blue for i=1:10
-        sleep(0.1)
-    end
-    @showprogress color=:yellow "Yellow: " showspeed=true for i=1:10
-        sleep(0.1)
-    end
-    @showprogress "Invisible: " enabled=false for i=1:10
         sleep(0.1)
     end
 end
 
 println("Testing keyword arguments")
-testfunc13()
 testfunc13a()
+testfunc13b()
 
 function testfunc14(barglyphs)
     n = 30
     # with the string constructor
     p = ProgressMeter.Progress(n, barglyphs=ProgressMeter.BarGlyphs(barglyphs))
     for i in 1:n
-        sleep(0.1)
+        sleep(0.05)
         ProgressMeter.next!(p)
     end
     # with the 5 char constructor
     chars = (barglyphs...,)
     p = ProgressMeter.Progress(n, barglyphs=ProgressMeter.BarGlyphs(chars...))
     for i in 1:n
-        sleep(0.1)
+        sleep(0.05)
         ProgressMeter.next!(p)
     end
     p = ProgressMeter.Progress(n, dt=0.01, desc="",
                                color=:red, output=stderr, barlen=40,
                                barglyphs=ProgressMeter.BarGlyphs(barglyphs))
     for i in 1:n
-        sleep(0.1)
+        sleep(0.05)
         ProgressMeter.next!(p)
     end
 end
@@ -276,7 +262,7 @@ testfunc14("[=> ]")
 
 # Threshold-based progress reports
 println("Testing threshold-based progress")
-prog = ProgressMeter.ProgressThresh(1e-5, "Minimizing:")
+prog = ProgressMeter.ProgressThresh(1e-5; desc="Minimizing:")
 for val in 10 .^ range(2, stop=-6, length=20)
     ProgressMeter.update!(prog, val)
     sleep(0.1)
@@ -286,51 +272,51 @@ end
 
 # Threshold-based progress reports with increment=false
 println("Testing threshold-based progress with increment=false")
-prog = ProgressMeter.ProgressThresh(1e-5, "Minimizing:")
+prog = ProgressMeter.ProgressThresh(1e-5, desc="Minimizing:")
 for val in 10 .^ range(2, stop=-6, length=20)
     ProgressMeter.update!(prog, val; increment=false)
     @test prog.counter == 0
     sleep(0.1)
 end
 colors = [:red, :blue, :green]
-prog = ProgressMeter.ProgressThresh(1e-5, "Minimizing:")
+prog = ProgressMeter.ProgressThresh(1e-5, desc="Minimizing:")
 for val in 10 .^ range(2, stop=-6, length=20)
-    ProgressMeter.update!(prog, val, rand(colors); increment=false)
+    ProgressMeter.update!(prog, val; color=rand(colors), increment=false)
     @test prog.counter == 0
     sleep(0.1)
 end
 
 # ProgressUnknown progress reports
 println("Testing progress unknown")
-prog = ProgressMeter.ProgressUnknown("Reading entry:")
+prog = ProgressMeter.ProgressUnknown(desc="Reading entry:")
 for _ in 1:10
     ProgressMeter.next!(prog)
     sleep(0.1)
 end
 ProgressMeter.finish!(prog)
 
-prog = ProgressMeter.ProgressUnknown("Reading entry:")
+prog = ProgressMeter.ProgressUnknown(desc="Reading entry:")
 for k in 1:2:20
     ProgressMeter.update!(prog, k)
     sleep(0.1)
 end
 
 colors = [:red, :blue, :green]
-prog = ProgressMeter.ProgressUnknown("Reading entry:")
+prog = ProgressMeter.ProgressUnknown(desc="Reading entry:")
 for k in 1:2:20
-    ProgressMeter.update!(prog, k, rand(colors))
+    ProgressMeter.update!(prog, k; color=rand(colors))
     sleep(0.1)
 end
 ProgressMeter.finish!(prog)
 
-prog = ProgressMeter.ProgressUnknown("Reading entry:", spinner=true)
+prog = ProgressMeter.ProgressUnknown(desc="Reading entry:", spinner=true)
 for _ in 1:10
     ProgressMeter.next!(prog)
     sleep(0.1)
 end
 ProgressMeter.finish!(prog)
 
-prog = ProgressMeter.ProgressUnknown("Reading entry:", spinner=true)
+prog = ProgressMeter.ProgressUnknown(desc="Reading entry:", spinner=true)
 for _ in 1:10
     ProgressMeter.next!(prog)
     sleep(0.1)
@@ -338,14 +324,14 @@ end
 ProgressMeter.finish!(prog, spinner='✗')
 
 myspinner = ['🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘']
-prog = ProgressUnknown("Custom spinner:", spinner=true)
+prog = ProgressUnknown(desc="Custom spinner:", spinner=true)
 for val in 1:10
     ProgressMeter.next!(prog, spinner=myspinner)
     sleep(0.1)
 end
 ProgressMeter.finish!(prog, spinner='🌞')
 
-prog = ProgressUnknown("Custom spinner:", spinner=true)
+prog = ProgressUnknown(desc="Custom spinner:", spinner=true)
 for val in 1:10
     ProgressMeter.next!(prog, spinner="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
     sleep(0.1)
@@ -362,7 +348,7 @@ for front in (['▏','▎','▍','▌','▋','▊', '▉'], ['▁' ,'▂' ,'▃'
 end
 
 function testfunc15(n, dt, tsleep)
-    result = ProgressMeter.@showprogress dt @distributed (+) for i in 1:n
+    result = ProgressMeter.@showprogress dt=dt @distributed (+) for i in 1:n
         if rand() < 0.7
             sleep(tsleep)
         end
@@ -372,10 +358,10 @@ function testfunc15(n, dt, tsleep)
 end
 
 println("Testing @showprogress macro on distributed for loop with reducer")
-testfunc15(3000, 0.01, 0.002)
+testfunc15(3000, 0.01, 0.001)
 
 function testfunc16(n, dt, tsleep)
-    ProgressMeter.@showprogress dt "Description: " @distributed for i in 1:n
+    ProgressMeter.@showprogress dt=dt desc="Description: " @distributed for i in 1:n
         if rand() < 0.7
             sleep(tsleep)
         end
@@ -384,7 +370,7 @@ function testfunc16(n, dt, tsleep)
 end
 
 println("Testing @showprogress macro on distributed for loop without reducer")
-testfunc16(3000, 0.01, 0.002)
+testfunc16(3000, 0.01, 0.001)
 
 function testfunc17()
     n = 30
@@ -408,7 +394,7 @@ function testfunc18A(n, dt, tsleep; start=15)
 end
 
 function testfunc18B(n, dt, tsleep)
-    p = ProgressMeter.ProgressUnknown(n; dt=dt, showspeed=true)
+    p = ProgressMeter.ProgressUnknown(; dt=dt, showspeed=true)
     for _ in 1:n
         sleep(tsleep)
         ProgressMeter.next!(p)

--- a/test/test.jl
+++ b/test/test.jl
@@ -454,3 +454,39 @@ println("Testing early cancel with offset 1 and keep")
 testfunc20(1:50, Progress(100, offset=1))
 testfunc20(1:50, ProgressUnknown(offset=1))
 testfunc20(50:-1:1, ProgressThresh(0, offset=1))
+
+function testfunc21()
+    p = Progress(10; desc="length 10:")
+    for i in 1:5
+        next!(p)
+        sleep(0.2)
+    end
+    update!(p; max_steps = 100, desc="now 100:")
+    sleep(0.5)
+    @test p.n == 100
+    for i in 6:100
+        next!(p)
+        sleep(0.05)
+    end
+end
+
+println("Testing updating max_steps")
+testfunc21()
+
+function testfunc22()
+    p = ProgressThresh(0.1; desc="thresh 0.1:")
+    for i in 1:5
+        update!(p, 1/i)
+        sleep(0.2)
+    end
+    update!(p; thresh=0.01, desc="now 0.01:")
+    sleep(0.5)
+    @test p.thresh == 0.01
+    for i in 6:101
+        update!(p, 1/i)
+        sleep(0.05)
+    end
+end
+
+println("Testing updating thresh")
+testfunc22()

--- a/test/test_float.jl
+++ b/test/test_float.jl
@@ -1,18 +1,18 @@
 println("Testing floating normal progress bar (offset 4)")
 function testfunc1(n, dt, tsleep, desc, barlen, offset)
-    p = ProgressMeter.Progress(n, dt, desc, barlen, offset=offset)
+    p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen, offset=offset)
     for i = 1:n
         sleep(tsleep)
         ProgressMeter.next!(p)
     end
     print("\n" ^ 5)
 end
-testfunc1(50, 0.2, 0.2, "progress  ", 70, 4)
+testfunc1(30, 0.1, 0.1, "progress  ", 70, 4)
 
 println("Testing floating normal progress bars with values and keep (2 levels)")
 function testfunc2(n, dt, tsleep, desc, barlen)
-    p1 = ProgressMeter.Progress(n, dt, desc, barlen, offset=0)
-    p2 = ProgressMeter.Progress(n, dt, desc, barlen, offset=5)
+    p1 = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen, offset=0)
+    p2 = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen, offset=5)
     for i = 1:n
         sleep(tsleep)
         ProgressMeter.next!(p1; showvalues = [(:i, i),
@@ -26,8 +26,8 @@ testfunc2(50, 0.2, 0.2, "progress  ", 70)
 
 println("Testing floating normal progress bars with changing offset")
 function testfunc3(n, dt, tsleep, desc, barlen)
-    p1 = ProgressMeter.Progress(n, dt, desc, barlen, offset=0)
-    p2 = ProgressMeter.Progress(n, dt, desc, barlen, offset=1)
+    p1 = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen, offset=0)
+    p2 = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen,offset=1)
     for i = 1:n
         sleep(tsleep)
         ProgressMeter.next!(p1; showvalues = [(:i, i) for _ in 1:i], keep=false)
@@ -40,7 +40,7 @@ testfunc3(10, 0.2, 0.5, "progress  ", 70)
 
 println("Testing floating thresh progress bar (offset 2)")
 function testfunc4(thresh, dt, tsleep, desc, offset)
-    prog = ProgressMeter.ProgressThresh(thresh, dt, desc, offset=offset)
+    prog = ProgressMeter.ProgressThresh(thresh; dt=dt, desc=desc, offset=offset)
     for val in 10 .^ range(2, stop=-6, length=20)
         ProgressMeter.update!(prog, val)
         sleep(tsleep)
@@ -51,9 +51,9 @@ testfunc4(1e-5, 0.2, 0.2, "Minimizing: ", 2)
 
 println("Testing floating in @showprogress macro (3 levels)")
 function testfunc5(n, tsleep)
-    ProgressMeter.@showprogress "Level 0 " for i in 1:n
-        ProgressMeter.@showprogress " Level 1 " 1 for i2 in 1:n
-            ProgressMeter.@showprogress "  Level 2 " 2 for i3 in 1:n
+    ProgressMeter.@showprogress desc="Level 0 " for i in 1:n
+        ProgressMeter.@showprogress desc=" Level 1 " offset=1 for i2 in 1:n
+            ProgressMeter.@showprogress desc="  Level 2 " offset=2 for i3 in 1:n
                 sleep(tsleep)
             end
         end
@@ -64,7 +64,7 @@ testfunc5(5, 0.1)
 
 println("Testing floating unknown progress bar (offset 2)")
 function testfunc6(desc, n, tsleep, offset)
-    p = ProgressMeter.ProgressUnknown(desc; offset=offset)
+    p = ProgressMeter.ProgressUnknown(desc=desc, offset=offset)
     for i = 1:n
         sleep(tsleep)
         ProgressMeter.next!(p)

--- a/test/test_map.jl
+++ b/test/test_map.jl
@@ -108,7 +108,7 @@ procs = addprocs(2)
 
 
     # Progress args
-    vals = @showprogress 0.1 "Computing" pmap(testfun, 1:10)
+    vals = @showprogress dt=0.1 desc="Computing" pmap(testfun, 1:10)
     @test vals == map(testfun, 1:10)
 
 

--- a/test/test_showvalues.jl
+++ b/test/test_showvalues.jl
@@ -7,7 +7,7 @@ lazy_no_lazy(values) = (rand() < 0.5) ? values : () -> values
 
 println("Testing showvalues with a Dict (2 values)")
 function testfunc1(n, dt, tsleep, desc, barlen)
-    p = ProgressMeter.Progress(n, dt, desc, barlen)
+    p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen)
     for i = 1:n
         sleep(tsleep)
         values = Dict(:i => i, :halfdone => (i >= n/2))
@@ -18,7 +18,7 @@ testfunc1(50, 1, 0.2, "progress  ", 70)
 
 println("Testing showvalues with an Array of tuples (4 values)")
 function testfunc2(n, dt, tsleep, desc, barlen)
-    p = ProgressMeter.Progress(n, dt, desc, barlen)
+    p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen)
     for i = 1:n
         sleep(tsleep)
         values = [(:i, i), (:constant, "foo"), (:isq, i^2), (:large, 2^i)]
@@ -29,7 +29,7 @@ testfunc2(30, 1, 0.2, "progress  ", 60)
 
 println("Testing showvalues when types of names differ (3 values)")
 function testfunc3(n, dt, tsleep, desc, barlen)
-    p = ProgressMeter.Progress(n, dt, desc, barlen)
+    p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen)
     for i = 1:n
         sleep(tsleep)
         values = [(:i, i*10), ("constant", "foo"), 
@@ -41,7 +41,7 @@ testfunc3(30, 1, 0.2, "progress  ", 70)
 
 println("Testing progress with showing values when num values to print changes between iterations")
 function testfunc4(n, dt, tsleep, desc, barlen)
-    p = ProgressMeter.Progress(n, dt, desc, barlen)
+    p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen)
     for i = 1:n
         sleep(tsleep)
         values_pool = [(:i, i*10), ("constant", "foo"), 
@@ -64,7 +64,7 @@ end
 
 println("Testing showvalues with a different color (1 value)")
 function testfunc5(n, dt, tsleep, desc, barlen)
-    p = ProgressMeter.Progress(n, dt, desc, barlen)
+    p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen)
     for i = 1:n
         sleep(tsleep)
         values = [(:large, 2^i)]
@@ -75,7 +75,7 @@ end
 testfunc5(10, 1, 0.2, "progress  ", 40)
 
 println("Testing showvalues with threshold-based progress")
-prog = ProgressMeter.ProgressThresh(1e-5, "Minimizing:")
+prog = ProgressMeter.ProgressThresh(1e-5; desc="Minimizing:")
 for val in 10 .^ range(2, stop=-6, length=20)
     values = Dict(:margin => abs(val - 1e-5))
     ProgressMeter.update!(prog, val; showvalues = lazy_no_lazy(values))
@@ -83,7 +83,7 @@ for val in 10 .^ range(2, stop=-6, length=20)
 end
 
 println("Testing showvalues with online progress")
-prog = ProgressMeter.ProgressUnknown("Entries read:")
+prog = ProgressMeter.ProgressUnknown(desc="Entries read:")
 for title in ["a", "b", "c", "d", "e"]
     values = Dict(:title => title)
     ProgressMeter.next!(prog; showvalues = lazy_no_lazy(values))
@@ -93,7 +93,7 @@ ProgressMeter.finish!(prog)
 
 
 println("Testing showvalues with early cancel")
-prog = ProgressMeter.Progress(100, 1, "progress: ", 70)
+prog = ProgressMeter.Progress(100; dt=1, desc="progress: ", barlen=70)
 for i in 1:50
     values = Dict(:left => 100 - i)
     ProgressMeter.update!(prog, i; showvalues = lazy_no_lazy(values))
@@ -103,7 +103,7 @@ ProgressMeter.cancel(prog)
 
 
 println("Testing showvalues with truncate")
-prog = ProgressMeter.Progress(50, 1, "progress: ")
+prog = ProgressMeter.Progress(50; dt=1, desc="progress: ")
 for i in 1:50
     values = Dict(:left => 100 - i, :message => repeat("0123456789", i))
     ProgressMeter.update!(prog, i; 

--- a/test/test_threads.jl
+++ b/test/test_threads.jl
@@ -19,7 +19,7 @@
 
     println("Testing ProgressUnknown() with Threads.@threads across $threads threads")
     trigger = 100.0
-    prog = ProgressMeter.ProgressUnknown("Attepts at exceeding trigger:")
+    prog = ProgressMeter.ProgressUnknown(desc="Attempts at exceeding trigger:")
     vals = Float64[]
     threadsUsed = Int[]
     Threads.@threads for _ in 1:1000
@@ -42,7 +42,7 @@
 
     println("Testing ProgressThresh() with Threads.@threads across $threads threads")
     thresh = 1.0
-    prog = ProgressMeter.ProgressThresh(thresh, "Minimizing:")
+    prog = ProgressMeter.ProgressThresh(thresh; desc="Minimizing:")
     vals = fill(300.0, 1)
     threadsUsed = Int[]
     Threads.@threads for _ in 1:100000


### PR DESCRIPTION
deprecates non-kwargs methods to build progresses and `next!`/`update!`

for example:
```julia
Progress(10; desc="My progress")
ProgressUnknown(desc = "Computing...", color=:red)
next!(p; desc="New description")
update!(p; color=:blue)
```

also adds `max_steps` and `thresh` as kwargs for `next!` and `update!`. I'm not sure about the name `max_steps`, but I don't like `max` or `n`, feel free to suggest something else.

closes #33, closes #160, closes #165, closes #220, closes #225, closes #254, closes #259