### PR TITLE
add support for using @showprogress on Threads.@threads for loops

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -841,20 +841,13 @@ function showprogressdistributed(args...)
 end
 
 function showprogressthreads(args...)
-    if length(args) < 1
-        throw(ArgumentError("@showprogress Threads.@threads requires at least 1 argument"))
-    end
-
     progressargs = args[1:end-1]
     expr = args[end]
-    loop = expr
-    if loop.head == :macrocall && loop.args[1] == :(Threads.var"@threads")
-        loop = loop.args[end]
-    end
-
+    loop = expr.args[end]
+    r = loop.args[1].args[end]
     p = gensym()
     n = gensym()
-    r = loop.args[1].args[end]
+
     ex = quote
         $n = Int(round(length($(esc(r))) / Threads.nthreads()))
         global $p
@@ -869,6 +862,7 @@ function showprogressthreads(args...)
         end
     end
     push!(loop.args[end].args, update)
+
     ex
 end
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -476,3 +476,17 @@ end
 
 println("Testing updating thresh")
 testfunc22()
+
+function testfunc23(n, dt, tsleep)
+    result = zeros(n)
+    ProgressMeter.@showprogress dt=dt Threads.@threads for i in 1:n
+        if rand() < 0.7
+            sleep(tsleep)
+        end
+        result[i] = i ^ 2
+    end
+    @test sum(result) == sum(abs2.(1:n))
+end
+
+println("Testing @showprogress macro on Threads.@threads for loop")
+testfunc23(3000, 0.01, 0.001)

--- a/test/test.jl
+++ b/test/test.jl
@@ -476,18 +476,3 @@ end
 
 println("Testing updating thresh")
 testfunc22()
-
-@static if VERSION >= v"1.3.0-rc1" # the Threads.@threads macro is parsed differently before 1.3
-    println("Testing @showprogress macro on Threads.@threads for loop")
-    function testfunc23(n, dt, tsleep)
-        result = zeros(n)
-        ProgressMeter.@showprogress dt=dt Threads.@threads for i in 1:n
-            if rand() < 0.7
-                sleep(tsleep)
-            end
-            result[i] = i ^ 2
-        end
-        @test sum(result) == sum(abs2.(1:n))
-    end
-    testfunc23(3000, 0.01, 0.001)
-end

--- a/test/test.jl
+++ b/test/test.jl
@@ -477,16 +477,17 @@ end
 println("Testing updating thresh")
 testfunc22()
 
-function testfunc23(n, dt, tsleep)
-    result = zeros(n)
-    ProgressMeter.@showprogress dt=dt Threads.@threads for i in 1:n
-        if rand() < 0.7
-            sleep(tsleep)
+@static if VERSION >= v"1.3.0-rc1" # the Threads.@threads macro is parsed differently before 1.3
+    println("Testing @showprogress macro on Threads.@threads for loop")
+    function testfunc23(n, dt, tsleep)
+        result = zeros(n)
+        ProgressMeter.@showprogress dt=dt Threads.@threads for i in 1:n
+            if rand() < 0.7
+                sleep(tsleep)
+            end
+            result[i] = i ^ 2
         end
-        result[i] = i ^ 2
+        @test sum(result) == sum(abs2.(1:n))
     end
-    @test sum(result) == sum(abs2.(1:n))
+    testfunc23(3000, 0.01, 0.001)
 end
-
-println("Testing @showprogress macro on Threads.@threads for loop")
-testfunc23(3000, 0.01, 0.001)

--- a/test/test_threads.jl
+++ b/test/test_threads.jl
@@ -85,4 +85,20 @@
             @info "Threads.nthreads() == 1, so Threads.@spawn tests cannot be meaningfully tested"
         end
     end
+
+
+    @static if VERSION >= v"1.3.0-rc1" # the Threads.@threads macro is parsed differently before 1.3
+        println("Testing @showprogress on a Threads.@threads for loop")
+        function test_threaded_for_loop(n, dt, tsleep)
+	        result = zeros(n)
+	        ProgressMeter.@showprogress dt=dt Threads.@threads for i in 1:n
+                if rand() < 0.7
+                    sleep(tsleep)
+                end
+                result[i] = i ^ 2
+            end
+            @test sum(result) == sum(abs2.(1:n))
+        end
+        test_threaded_for_loop(3000, 0.01, 0.001)
+    end
 end


### PR DESCRIPTION
This lets you use the @showprogress macro on parallel for loops. For example,
```
@showprogress Threads.@threads for i in 1:100
    sleep(0.1)
end
```