### PR TITLE
add parameter for fractional bar length

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -98,7 +98,7 @@ mutable struct Progress <: AbstractProgress
         counter = start
         tinit = tsecond = tlast = time()
         printed = false
-        barlen = barlen isa Nothing ? barlen : Int(round(barlen*barlen_fraction))
+        barlen = barlen isa Nothing ? barlen : trunc(Int, (barlen*barlen_fraction))
         new(n, reentrantlocker, dt, counter, tinit, tsecond, tlast, printed, desc, barlen, barlen_fraction, barglyphs, color, output, offset, 0, start, enabled, showspeed, 1, 1, Int[])
     end
 end
@@ -206,7 +206,7 @@ end
 
 #...length of percentage and ETA string with days is 29 characters, speed string is always 14 extra characters
 function tty_width(desc, output, showspeed::Bool, width_fraction::Float64 = 1.0)
-    full_width = Int(round(displaysize(output)[2]*width_fraction))
+    full_width = trunc(Int, (displaysize(output)[2]*width_fraction))
     desc_width = length(desc)
     eta_width = 29
     speed_width = showspeed ? 14 : 0

--- a/test/test.jl
+++ b/test/test.jl
@@ -13,7 +13,7 @@ println("Testing original interface...")
 testfunc(107, 0.01, 0.01)
 
 
-function testfunc2(n, dt, tsleep, desc, barlen)
+function testfunc2A(n, dt, tsleep, desc, barlen)
     p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen)
     for i = 1:n
         sleep(tsleep)
@@ -21,9 +21,27 @@ function testfunc2(n, dt, tsleep, desc, barlen)
     end
 end
 println("Testing desc and progress bar")
-testfunc2(107, 0.01, 0.01, "Computing...", 50)
+testfunc2A(107, 0.01, 0.01, "Computing...", 50)
 println("Testing no desc and no progress bar")
-testfunc2(107, 0.01, 0.01, "", 0)
+testfunc2A(107, 0.01, 0.01, "", 0)
+
+
+function testfunc2B(n, dt, tsleep, desc, barlen, barlen_fraction)
+    p = ProgressMeter.Progress(n; dt=dt, desc=desc, barlen=barlen, barlen_fraction=barlen_fraction)
+    for i = 1:n
+        sleep(tsleep)
+        ProgressMeter.next!(p)
+    end
+end
+println("Testing desc and progress bar with fractional size")
+testfunc2B(107, 0.01, 0.01, "Computing...", nothing, 1.0)
+println("this one should be half the size")
+testfunc2B(107, 0.01, 0.01, "Computing...", nothing, 0.5)
+
+println("Combining barlen and fraction")
+testfunc2B(107, 0.01, 0.01, "Computing...", 50, 0.5)
+println("Testing no desc and no progress bar by scaling to zero")
+testfunc2B(107, 0.01, 0.01, "", nothing, 0.0)
 
 
 function testfunc3(n, tsleep, desc)


### PR DESCRIPTION
I find that the progress bar usually overflows when the ETA quickly converges from a large to a small value. Because of this, I want to make the bar shorter. However, since the TTY width is not immediately obvious to me, I would rather like to scale the length of the bar by some fraction. This PR adds this feature.

Summary of changes:
* Added the parameter `barlen_fraction` to the `Progress`-struct, which can take on any float. This means that the bar can be scaled negatively and larger than 1.

I might have added too much to the testing, and the argument might be too verbose.