### PR TITLE
tests: don't use single-argument `map`

### DIFF
--- a/test/test_map.jl
+++ b/test/test_map.jl
@@ -169,10 +169,8 @@ wp = WorkerPool(procs)
     function constfun()
         return 42
     end
-    @test map(constfun) == @showprogress map(constfun)
     @test broadcast(constfun) == @showprogress broadcast(constfun)
     #@test mapreduce(constfun, error) == @showprogress mapreduce(constfun, error) # julia 1.2+
-    @showprogress foreach(println∘constfun)
 
 
     # #136: make sure mid progress shows up even without sleep


### PR DESCRIPTION
Single-argument `map` is being removed from Julia after an analysis of registered packages found that the change doesn't break the functionality of any package. See JuliaLang/julia#35293 and JuliaLang/julia#52631

That said, the Julia change breaks your test suite, so here's a PR that fixes that.