### PR TITLE
allow for new map-like functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ end
 It possible to disable the progress meter when the use is optional.
 
 ```julia
-x,n = 1,10
+x, n = 1, 10
 p = Progress(n; enabled = false)
 for iter in 1:10
     x *= 2
@@ -431,7 +431,25 @@ In cases where the output is text output such as CI or in an HPC scheduler, the 
 ```julia
 is_logging(io) = isa(io, Base.TTY) == false || (get(ENV, "CI", nothing) == "true")
 p = Progress(n; output = stderr, enabled = !is_logging(stderr))
-````
+```
+
+### Adding support for more map-like functions
+
+To add support for other functions, `ProgressMeter.ncalls` must be defined,
+where `ncalls_map`, `ncalls_broadcast`, `ncalls_broadcast!` or `ncalls_reduce` can help
+
+For example, with `tmap` from [`ThreadTools.jl`](https://github.com/baggepinnen/ThreadTools.jl):
+
+```julia
+using ThreadTools, ProgressMeter
+
+ProgressMeter.ncalls(::typeof(tmap), ::Function, args...) = ProgressMeter.ncalls_map(args...)
+ProgressMeter.ncalls(::typeof(tmap), ::Function, ::Int, args...) = ProgressMeter.ncalls_map(args...)
+
+@showprogress tmap(abs2, 1:10^5)
+@showprogress tmap(abs2, 4, 1:10^5)
+```
+
 
 ## Development/debugging tips
 

--- a/test/test_map.jl
+++ b/test/test_map.jl
@@ -54,28 +54,50 @@ wp = WorkerPool(procs)
     println()
 
     # test ncalls
-    @test ncalls(map, (+, 1:10)) == 10
-    @test ncalls(pmap, (+, 1:10, 1:100)) == 10
-    @test ncalls(pmap, (+, wp, 1:10)) == 10
-    @test ncalls(reduce, (+, 1:10)) == 10
-    @test ncalls(mapreduce, (+, +, 1:10, (1:10)')) == 10
-    @test ncalls(mapfoldl, (+, +, 1:10, (1:10)')) == 10
-    @test ncalls(mapfoldr, (+, +, 1:10, (1:10)')) == 10
-    @test ncalls(foreach, (+, 1:10)) == 10
-    @test ncalls(broadcast, (+, 1:10, 1:10)) == 10
-    @test ncalls(broadcast, (+, 1:8, (1:7)', 1)) == 8*7
-    @test ncalls(broadcast, (+, 1:3, (1:5)', ones(1,1,2))) == 3*5*2
-    @test ncalls(broadcast!, (+, zeros(10,8))) == 80
-    @test ncalls(broadcast!, (+, zeros(10,8,7), 1:10)) == 10*8*7
+    @test ncalls(map, +, 1:10) == 10
+    @test ncalls(pmap, +, 1:10, 1:100) == 10
+    @test ncalls(pmap, +, wp, 1:10) == 10
+    @test ncalls(foldr, +, 1:10) == 9
+    @test ncalls(foldl, +, 1:10) == 9
+    @test ncalls(reduce, +, 1:10) == 9
+    @test ncalls(mapreduce, +, +, 1:10, (1:10)') == 10
+    @test ncalls(mapfoldl, +, +, 1:10, (1:10)') == 10
+    @test ncalls(mapfoldr, +, +, 1:10, (1:10)') == 10
+    @test ncalls(foreach, +, 1:10) == 10
+    @test ncalls(broadcast, +, 1:10, 1:10) == 10
+    @test ncalls(broadcast, +, 1:8, (1:7)', 1) == 8*7
+    @test ncalls(broadcast, +, 1:3, (1:5)', ones(1,1,2)) == 3*5*2
+    @test ncalls(broadcast!, +, zeros(10,8,7), 1:10) == 10*8*7
 
-    @test ncalls(map, (time,)) == 1
-    @test ncalls(foreach, (time,)) == 1
-    @test ncalls(broadcast, (time,)) == 1
-    @test ncalls(broadcast!, (time, [1])) == 1
-    @test ncalls(mapreduce, (time, +)) == 1
+    # functions with no args
+    # map(f) and foreach(f) were removed (#291)
+    @test ncalls(broadcast, time) == 1
+    @test ncalls(broadcast!, time, [1]) == 1
+    @test ncalls(broadcast!, time, zeros(10,8)) == 80
+    @test ncalls(mapreduce, time, +) == 1
 
-    @test_throws DimensionMismatch ncalls(broadcast, (+, 1:10, 1:100))
-    @test_throws DimensionMismatch ncalls(broadcast, (+, 1:100, 1:10))
+    @test_throws DimensionMismatch ncalls(broadcast, +, 1:10, 1:100)
+    @test_throws DimensionMismatch ncalls(broadcast, +, 1:100, 1:10)
+
+    @test_throws ArgumentError ncalls(map, 1:10, 1:10)
+    @test_throws ArgumentError ncalls(sum, 1:10)
+
+    # test custom mapfun
+    mymap(f, x) = map(f, [x ; x])
+    @test_throws ArgumentError ncalls(mymap, +, 1:10)
+    ProgressMeter.ncalls(::typeof(mymap), ::Function, args...) = 2*ProgressMeter.ncalls_map(args...)
+    @test ncalls(mymap, +, 1:10) == 20
+
+    println("Testing custom map")
+    vals = @showprogress mymap(1:10) do x
+        sleep(0.1)
+        return x^2
+    end
+    @test vals == map(x->x^2, [1:10; 1:10])
+
+    println("Testing custom map with kwarg (color red)")
+    vals = @showprogress color=:red mymap(x->(sleep(0.1); x^2), 1:10)
+    @test vals == map(x->x^2, [1:10; 1:10])
 
     # @showprogress
     vals = @showprogress map(1:10) do x
@@ -138,8 +160,6 @@ wp = WorkerPool(procs)
     end
     @test A == repeat(1:10, 1, 8)
 
-
-
     # function passed by name
     function testfun(x)
         return x^2
@@ -172,7 +192,6 @@ wp = WorkerPool(procs)
     @test broadcast(constfun) == @showprogress broadcast(constfun)
     #@test mapreduce(constfun, error) == @showprogress mapreduce(constfun, error) # julia 1.2+
 
-
     # #136: make sure mid progress shows up even without sleep
     println("Verify that intermediate progress is displayed:")
     @showprogress map(1:100) do i
@@ -184,24 +203,14 @@ wp = WorkerPool(procs)
     vals = @showprogress pmap((x,y)->x*y, 1:10, 2:11)
     @test vals == map((x,y)->x*y, 1:10, 2:11)
 
-
-
-
-
-
-
     # Progress args
     vals = @showprogress dt=0.1 desc="Computing" pmap(testfun, 1:10)
     @test vals == map(testfun, 1:10)
-
-
 
     # named vector arg
     a = collect(1:10)
     vals = @showprogress pmap(x->x^2, a)
     @test vals == map(x->x^2, a)
-
-    
 
     # global variable in do
     C = 10
@@ -210,15 +219,12 @@ wp = WorkerPool(procs)
     end
     @test vals == map(x->C*x, 1:10)
 
-
-
     # keyword arguments
     vals = @showprogress pmap(x->x^2, 1:100, batch_size=10)
     @test vals == map(x->x^2, 1:100)
     # with semicolon
     vals = @showprogress pmap(x->x^2, 1:100; batch_size=10)
     @test vals == map(x->x^2, 1:100)
-
     
     # pipes after map
     @showprogress map(testfun, 1:10) |> sum |> length


### PR DESCRIPTION
the `@showprogress` macro doesn't check anymore if functions are in a predefined list of allowed functions, instead, `ncalls` should be defined for the used function. This allows to add new map-like function, for example `tmap`:

```julia
using ThreadTools, ProgressMeter

ProgressMeter.ncalls(::typeof(tmap), ::Function, args...) = ProgressMeter.ncalls_map(args...)
ProgressMeter.ncalls(::typeof(tmap), ::Function, ::Int, args...) = ProgressMeter.ncalls_map(args...)

@showprogress tmap(abs2, 1:10^5)
@showprogress tmap(abs2, 4, 1:10^5)
```

fix #144, fix #251 