### PR TITLE
Drop Julia <1.6. Reduce code duplication by introducing ProgressCore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-          JULIA_NUM_THREADS: ${{ matrix.arch }}
+          JULIA_NUM_THREADS: ${{ matrix.nthreads }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '0.7'
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:
@@ -46,7 +45,6 @@ jobs:
         env:
           JULIA_NUM_THREADS: 1
       - uses: julia-actions/julia-runtest@v1
-        if: ${{ matrix.version != '0.7' && matrix.version != '1.0' }}
         env:
           JULIA_NUM_THREADS: 2
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
     tags: '*'
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,6 +23,9 @@ jobs:
           - windows-latest
         arch:
           - x64
+        nthreads:
+          - 1
+          - 2
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
@@ -34,10 +36,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-          JULIA_NUM_THREADS: 1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          JULIA_NUM_THREADS: 2
+          JULIA_NUM_THREADS: ${{ matrix.arch }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-julia = "0.7, 1"
+julia = "1.6"
 
 [extras]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -47,7 +47,7 @@ function BarGlyphs(s::AbstractString)
 end
 const defaultglyphs = BarGlyphs('|','█', Sys.iswindows() ? '█' : ['▏','▎','▍','▌','▋','▊','▉'],' ','|',)
 
-# Internal struct for holding common properties for progress meters
+# Internal struct for holding common properties and internals for progress meters
 Base.@kwdef mutable struct ProgressCore
     color::Symbol               = :green        # color of the meter
     desc::String                = "Progress: "  # prefix to the percentage, e.g.  "Computing..."

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -440,7 +440,7 @@ end
 
 function lock_if_threading(f::Function, p::AbstractProgress)
     if is_threading(p)
-        lock(p.reentrantlocker) do
+        lock(p.lock) do
             f()
         end
     else


### PR DESCRIPTION
- Drops julia versions <1.6 (very old now, so not worth supporting given even things like `hasfield` aren't defined)
- Reduces code duplication .There's a fair bit of duplication between the three core Progress types. This puts the common elements into a `ProgressCore` struct to avoid duplication.