### PR TITLE
fix possible concurrency in is_threading

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -441,25 +441,6 @@ end
 
 predicted_updates_per_dt_have_passed(p::AbstractProgress) = p.counter - p.prev_update_count >= p.check_iterations
 
-function is_threading(p::AbstractProgress)
-    Threads.nthreads() == 1 && return false
-    length(p.threads_used) > 1 && return true
-    if !in(Threads.threadid(), p.threads_used)
-        push!(p.threads_used, Threads.threadid())
-    end
-    return length(p.threads_used) > 1
-end
-
-function lock_if_threading(f::Function, p::AbstractProgress)
-    if is_threading(p)
-        lock(p.lock) do
-            f()
-        end
-    else
-        f()
-    end
-end
-
 # update progress display
 """
     next!(p::Union{Progress, ProgressUnknown}; step::Int = 1, options...)
@@ -470,7 +451,7 @@ the last update, this may or may not result in a change to the display.
 You may optionally change the `color` of the display. See also `update!`.
 """
 function next!(p::Union{Progress, ProgressUnknown}; step::Int = 1, options...)
-    lock_if_threading(p) do
+    lock(p.lock) do
         p.counter += step
         updateProgress!(p; ignore_predictor = step == 0, options...)
     end
@@ -486,7 +467,7 @@ this may or may not result in a change to the display.
 You may optionally change the color of the display. See also `next!`.
 """
 function update!(p::Union{Progress, ProgressUnknown}, counter::Int=p.counter; options...)
-    lock_if_threading(p) do
+    lock(p.lock) do
         counter_changed = p.counter != counter
         p.counter = counter
         updateProgress!(p; ignore_predictor = !counter_changed, options...)
@@ -499,7 +480,7 @@ end
 Set the progress counter to current value `val`.
 """
 function update!(p::ProgressThresh, val=p.val; increment::Bool = true, options...)
-    lock_if_threading(p) do
+    lock(p.lock) do
         p.val = val
         if increment
             p.counter += 1
@@ -520,7 +501,7 @@ See also `finish!`.
 function cancel(p::AbstractProgress, msg::AbstractString = "Aborted before all tasks were completed";
                 color = :red, showvalues = (), truncate_lines = false,
                 valuecolor = :blue, offset = p.offset, keep = (offset == 0))
-    lock_if_threading(p) do
+    lock(p.lock) do
         p.offset = offset
         if p.printed
             print(p.output, "\n" ^ (p.offset + p.numprintedvalues))
@@ -555,7 +536,7 @@ function finish!(p::ProgressThresh; options...)
 end
 
 function finish!(p::ProgressUnknown; options...)
-    lock_if_threading(p) do
+    lock(p.lock) do
         p.done = true
         updateProgress!(p; options...)
     end

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -77,11 +77,10 @@ Base.@kwdef mutable struct ProgressCore
     # internals
     check_iterations::Int       = 1             # number of iterations to check time for
     counter::Int                = 0             # current iteration
-    lock::Threads.ReentrantLock = Threads.ReentrantLock()   # lock used when threading detected
+    lock::Threads.ReentrantLock = Threads.ReentrantLock()   # lock necessary when threading 
     numprintedvalues::Int       = 0             # num values printed below progress in last iteration
     prev_update_count::Int      = 1             # counter at last update
     printed::Bool               = false         # true if we have issued at least one status update
-    threads_used::Vector{Int}   = Int[]         # threads that have used this progress meter
     tinit::Float64              = time()        # time meter was initialized
     tlast::Float64              = time()        # time of last update
     tsecond::Float64            = time()        # ignore the first loop given usually uncharacteristically slow


### PR DESCRIPTION

This fixes https://github.com/timholy/ProgressMeter.jl/issues/317

I think the issue is a concurrency that may occur in the `is_threading` function. 

I'm not sure if that function is necessary at all. The issue can be removed by always using the lock, and probably in serial runs the cost of that is irrelevant.

But maybe the bug reflects something deeper, so this might be the wrong fix.

(there is one test failing, but it is not related to this change)