### PR TITLE
Locked threadid update

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -822,7 +822,7 @@ function showprogressthreads(args...)
             length($(esc(iters)));
             $(showprogress_process_args(progressargs)...),
         )
-        $(esc(p)).threads_used .= true
+        $(esc(p)).threading.detected = true
         $(esc(expr))
         finish!($(esc(p)))
     end

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -66,7 +66,7 @@ end
 const defaultglyphs = BarGlyphs('|','█', Sys.iswindows() ? '█' : ['▏','▎','▍','▌','▋','▊','▉'],' ','|',)
 
 # Internal struct for holding threading information
-Base.@kwdef struct ThreadingInfo
+Base.@kwdef mutable struct ThreadingInfo
     detected::Bool = false
     threads_used::Vector{Bool} = fill(false, Threads.nthreads())
 end

--- a/test/test_threads.jl
+++ b/test/test_threads.jl
@@ -20,7 +20,6 @@
     println("Testing ProgressUnknown() with Threads.@threads across $threads threads")
     trigger = 100.0
     prog = ProgressUnknown(desc="Attempts at exceeding trigger:")
-    prog.threads_used .= true
     vals = Float64[]
     threadsUsed = fill(false, threads)
     lk = ReentrantLock()
@@ -47,7 +46,6 @@
     println("Testing ProgressThresh() with Threads.@threads across $threads threads")
     thresh = 1.0
     prog = ProgressThresh(thresh; desc="Minimizing:")
-    prog.threads_used .= true
     vals = fill(300.0, 1)
     threadsUsed = fill(false, threads)
     Threads.@threads for _ in 1:100000
@@ -75,7 +73,6 @@
         # threadsUsed = fill(false, threads)
         vals = ones(n*threads)
         p = Progress(n*threads)
-        p.threads_used .= true
 
         for t in 1:threads
             tasks[t] = Threads.@spawn for i in 1:n

--- a/test/test_threads.jl
+++ b/test/test_threads.jl
@@ -7,7 +7,6 @@
     threadsUsed = fill(false, threads)
     vals = ones(n*threads)
     p = Progress(n*threads)
-    p.threads_used = 1:threads # short-circuit the function `is_threading` because it is racy (#232)
     Threads.@threads for i = 1:(n*threads)
         threadsUsed[Threads.threadid()] = true
         vals[i] = 0
@@ -21,7 +20,7 @@
     println("Testing ProgressUnknown() with Threads.@threads across $threads threads")
     trigger = 100.0
     prog = ProgressUnknown(desc="Attempts at exceeding trigger:")
-    prog.threads_used = 1:threads
+    prog.threads_used .= true
     vals = Float64[]
     threadsUsed = fill(false, threads)
     lk = ReentrantLock()
@@ -48,7 +47,7 @@
     println("Testing ProgressThresh() with Threads.@threads across $threads threads")
     thresh = 1.0
     prog = ProgressThresh(thresh; desc="Minimizing:")
-    prog.threads_used = 1:threads
+    prog.threads_used .= true
     vals = fill(300.0, 1)
     threadsUsed = fill(false, threads)
     Threads.@threads for _ in 1:100000
@@ -76,7 +75,7 @@
         # threadsUsed = fill(false, threads)
         vals = ones(n*threads)
         p = Progress(n*threads)
-        p.threads_used = 1:threads
+        p.threads_used .= true
 
         for t in 1:threads
             tasks[t] = Threads.@spawn for i in 1:n


### PR DESCRIPTION
Another possible fix for: https://github.com/timholy/ProgressMeter.jl/issues/317 and https://github.com/timholy/ProgressMeter.jl/issues/232

In this case, the treading is detected by updating the `ThreadInfo` structure. This structure carries a bool, `detected`, that will cause the immediate return from `is_threading` once threading was detected. The field `threads_detected` will accumulate at most 2 different `threadid()`s, and is updated thread-safely with a lock. But this lock is only used until two different thread ids are detected, thus the cost of this should be minor.

