### PR TITLE
simple lock for threads_used update

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -77,11 +77,11 @@ Base.@kwdef mutable struct ProgressCore
     # internals
     check_iterations::Int       = 1             # number of iterations to check time for
     counter::Int                = 0             # current iteration
-    lock::Threads.ReentrantLock = Threads.ReentrantLock() # lock used when threading detected
+    lock::Threads.ReentrantLock = Threads.ReentrantLock()  # lock used when threading detected
     numprintedvalues::Int       = 0             # num values printed below progress in last iteration
     prev_update_count::Int      = 1             # counter at last update
     printed::Bool               = false         # true if we have issued at least one status update
-    threads_used_lock::ReentrantLock = ReentrantLock() # lock for threads_used update
+    threads_used_lock::ReentrantLock = ReentrantLock()  # lock for threads_used update
     threads_used::Vector{Int}   = Int[]         # threads that have used this progress meter
     tinit::Float64              = time()        # time meter was initialized
     tlast::Float64              = time()        # time of last update
@@ -445,7 +445,7 @@ predicted_updates_per_dt_have_passed(p::AbstractProgress) = p.counter - p.prev_u
 function is_threading(p::AbstractProgress)
     Threads.nthreads() == 1 && return false
     length(p.threads_used) > 1 && return true
-    if !(Threads.threadid() in p.threads_used)
+    if !in(Threads.threadid(), p.threads_used)
         lock(p.threads_used_lock) do
             push!(p.threads_used, Threads.threadid())
         end

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -77,11 +77,11 @@ Base.@kwdef mutable struct ProgressCore
     # internals
     check_iterations::Int       = 1             # number of iterations to check time for
     counter::Int                = 0             # current iteration
-    lock::Threads.ReentrantLock = Threads.ReentrantLock()  # lock used when threading detected
+    lock::Threads.ReentrantLock = Threads.ReentrantLock()   # lock used when threading detected
     numprintedvalues::Int       = 0             # num values printed below progress in last iteration
     prev_update_count::Int      = 1             # counter at last update
     printed::Bool               = false         # true if we have issued at least one status update
-    threads_used_lock::ReentrantLock = ReentrantLock()  # lock for threads_used update
+    threads_used_lock::ReentrantLock = ReentrantLock()   # lock for threads_used update
     threads_used::Vector{Int}   = Int[]         # threads that have used this progress meter
     tinit::Float64              = time()        # time meter was initialized
     tlast::Float64              = time()        # time of last update

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -445,8 +445,8 @@ predicted_updates_per_dt_have_passed(p::AbstractProgress) = p.counter - p.prev_u
 function is_threading(p::AbstractProgress)
     Threads.nthreads() == 1 && return false
     length(p.threads_used) > 1 && return true
-    lock(p.threads_used_lock) do
-        if !in(Threads.threadid(), p.threads_used)
+    if !(Threads.threadid() in p.threads_used)
+        lock(p.threads_used_lock) do
             push!(p.threads_used, Threads.threadid())
         end
     end

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -77,10 +77,11 @@ Base.@kwdef mutable struct ProgressCore
     # internals
     check_iterations::Int       = 1             # number of iterations to check time for
     counter::Int                = 0             # current iteration
-    lock::Threads.ReentrantLock = Threads.ReentrantLock()   # lock used when threading detected
+    lock::Threads.ReentrantLock = Threads.ReentrantLock() # lock used when threading detected
     numprintedvalues::Int       = 0             # num values printed below progress in last iteration
     prev_update_count::Int      = 1             # counter at last update
     printed::Bool               = false         # true if we have issued at least one status update
+    threads_used_lock::ReentrantLock = ReentrantLock() # lock for threads_used update
     threads_used::Vector{Int}   = Int[]         # threads that have used this progress meter
     tinit::Float64              = time()        # time meter was initialized
     tlast::Float64              = time()        # time of last update
@@ -444,8 +445,10 @@ predicted_updates_per_dt_have_passed(p::AbstractProgress) = p.counter - p.prev_u
 function is_threading(p::AbstractProgress)
     Threads.nthreads() == 1 && return false
     length(p.threads_used) > 1 && return true
-    if !in(Threads.threadid(), p.threads_used)
-        push!(p.threads_used, Threads.threadid())
+    lock(p.threads_used_lock) do
+        if !in(Threads.threadid(), p.threads_used)
+            push!(p.threads_used, Threads.threadid())
+        end
     end
     return length(p.threads_used) > 1
 end

--- a/test/test_threads.jl
+++ b/test/test_threads.jl
@@ -7,7 +7,6 @@
     threadsUsed = fill(false, threads)
     vals = ones(n*threads)
     p = Progress(n*threads)
-    p.threads_used = 1:threads # short-circuit the function `is_threading` because it is racy (#232)
     Threads.@threads for i = 1:(n*threads)
         threadsUsed[Threads.threadid()] = true
         vals[i] = 0
@@ -21,7 +20,6 @@
     println("Testing ProgressUnknown() with Threads.@threads across $threads threads")
     trigger = 100.0
     prog = ProgressUnknown(desc="Attempts at exceeding trigger:")
-    prog.threads_used = 1:threads
     vals = Float64[]
     threadsUsed = fill(false, threads)
     lk = ReentrantLock()
@@ -48,7 +46,6 @@
     println("Testing ProgressThresh() with Threads.@threads across $threads threads")
     thresh = 1.0
     prog = ProgressThresh(thresh; desc="Minimizing:")
-    prog.threads_used = 1:threads
     vals = fill(300.0, 1)
     threadsUsed = fill(false, threads)
     Threads.@threads for _ in 1:100000
@@ -76,7 +73,6 @@
         # threadsUsed = fill(false, threads)
         vals = ones(n*threads)
         p = Progress(n*threads)
-        p.threads_used = 1:threads
 
         for t in 1:threads
             tasks[t] = Threads.@spawn for i in 1:n


### PR DESCRIPTION
Simple fix for https://github.com/timholy/ProgressMeter.jl/issues/317 and https://github.com/timholy/ProgressMeter.jl/issues/232

This PR has the same effect as https://github.com/timholy/ProgressMeter.jl/pull/320 but is a simpler modification of the original code. I just added a lock to update `threads_used`. The update of `threads_used` occurs only twice at most, so this lock is very likely not important for performance. 