### PR TITLE
lock by default - add safe_lock option for control

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -81,7 +81,7 @@ Base.@kwdef mutable struct ProgressCore
     numprintedvalues::Int       = 0             # num values printed below progress in last iteration
     prev_update_count::Int      = 1             # counter at last update
     printed::Bool               = false         # true if we have issued at least one status update
-    safe_lock::Bool             = true          # set to false for non-threaded tight loops
+    safe_lock::Bool             = Threads.nthreads() > 1 # set to false for non-threaded tight loops
     tinit::Float64              = time()        # time meter was initialized
     tlast::Float64              = time()        # time of last update
     tsecond::Float64            = time()        # ignore the first loop given usually uncharacteristically slow

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -81,7 +81,7 @@ Base.@kwdef mutable struct ProgressCore
     numprintedvalues::Int       = 0             # num values printed below progress in last iteration
     prev_update_count::Int      = 1             # counter at last update
     printed::Bool               = false         # true if we have issued at least one status update
-    disable_lock::Bool          = false          # set to false for non-threaded tight loops
+    disable_lock::Bool          = false         # set to false for non-threaded tight loops
     tinit::Float64              = time()        # time meter was initialized
     tlast::Float64              = time()        # time of last update
     tsecond::Float64            = time()        # ignore the first loop given usually uncharacteristically slow

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -81,7 +81,7 @@ Base.@kwdef mutable struct ProgressCore
     numprintedvalues::Int       = 0             # num values printed below progress in last iteration
     prev_update_count::Int      = 1             # counter at last update
     printed::Bool               = false         # true if we have issued at least one status update
-    threads_used::Vector{Int}   = Int[]         # threads that have used this progress meter
+    disable_lock::Bool          = false          # set to false for non-threaded tight loops
     tinit::Float64              = time()        # time meter was initialized
     tlast::Float64              = time()        # time of last update
     tsecond::Float64            = time()        # ignore the first loop given usually uncharacteristically slow
@@ -441,22 +441,13 @@ end
 
 predicted_updates_per_dt_have_passed(p::AbstractProgress) = p.counter - p.prev_update_count >= p.check_iterations
 
-function is_threading(p::AbstractProgress)
-    Threads.nthreads() == 1 && return false
-    length(p.threads_used) > 1 && return true
-    if !in(Threads.threadid(), p.threads_used)
-        push!(p.threads_used, Threads.threadid())
-    end
-    return length(p.threads_used) > 1
-end
-
 function lock_if_threading(f::Function, p::AbstractProgress)
-    if is_threading(p)
+    if p.disable_lock
+        f()
+    else
         lock(p.lock) do
             f()
         end
-    else
-        f()
     end
 end
 
@@ -817,7 +808,6 @@ function showprogressthreads(args...)
             length($(esc(iters)));
             $(showprogress_process_args(progressargs)...),
         )
-        append!($(esc(p)).threads_used, 1:Threads.nthreads())
         $(esc(expr))
         finish!($(esc(p)))
     end

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -81,7 +81,7 @@ Base.@kwdef mutable struct ProgressCore
     numprintedvalues::Int       = 0             # num values printed below progress in last iteration
     prev_update_count::Int      = 1             # counter at last update
     printed::Bool               = false         # true if we have issued at least one status update
-    disable_lock::Bool          = false         # set to false for non-threaded tight loops
+    safe_lock::Bool             = true          # set to false for non-threaded tight loops
     tinit::Float64              = time()        # time meter was initialized
     tlast::Float64              = time()        # time of last update
     tsecond::Float64            = time()        # ignore the first loop given usually uncharacteristically slow
@@ -442,12 +442,12 @@ end
 predicted_updates_per_dt_have_passed(p::AbstractProgress) = p.counter - p.prev_update_count >= p.check_iterations
 
 function lock_if_threading(f::Function, p::AbstractProgress)
-    if p.disable_lock
-        f()
-    else
+    if p.safe_lock
         lock(p.lock) do
             f()
         end
+    else
+        f()
     end
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -92,10 +92,7 @@ function simple_sum(n; safe_lock = true)
     return s
 end
 p = Progress(10)
-@test p.safe_lock == true
+@test p.safe_lock == Threads.nthreads() > 1
 p = Progress(10; safe_lock = false)
 @test p.safe_lock == false
-@test simple_sum(10) ≈ simple_sum(10; safe_lock = false)
-
-
-
+@test simple_sum(10; safe_lock = false) ≈ simple_sum(10; safe_lock = false)

--- a/test/core.jl
+++ b/test/core.jl
@@ -92,7 +92,7 @@ function simple_sum(n; safe_lock = true)
     return s
 end
 p = Progress(10)
-@test p.safe_lock == Threads.nthreads() > 1
+@test p.safe_lock == (Threads.nthreads() > 1)
 p = Progress(10; safe_lock = false)
 @test p.safe_lock == false
 @test simple_sum(10; safe_lock = false) ≈ simple_sum(10; safe_lock = false)

--- a/test/core.jl
+++ b/test/core.jl
@@ -95,4 +95,4 @@ p = Progress(10)
 @test p.safe_lock == (Threads.nthreads() > 1)
 p = Progress(10; safe_lock = false)
 @test p.safe_lock == false
-@test simple_sum(10; safe_lock = false) ≈ simple_sum(10; safe_lock = false)
+@test simple_sum(10; safe_lock = true) ≈ simple_sum(10; safe_lock = false)

--- a/test/core.jl
+++ b/test/core.jl
@@ -81,22 +81,21 @@ prog.n = UInt128(20) # in Progress
 prog.offset = Int8(5) # in ProgressCore
 @test prog.offset == 5
 
-# Test disable_lock option, initialization and
-# execution. 
-function simple_sum(n; disable_lock = false)
-    p = Progress(n; disable_lock)
+# Test safe_lock option, initialization and execution. 
+function simple_sum(n; safe_lock = true)
+    p = Progress(n; safe_lock)
     s = 0.0
     for i in 1:n
-        s += sin(i)
+        s += sin(i)^2
         next!(p)
     end
     return s
 end
 p = Progress(10)
-@test p.disable_lock == false
-p = Progress(10; disable_lock = true)
-@test p.disable_lock == true
-@test simple_sum(10) ≈ simple_sum(10; disable_lock = true)
+@test p.safe_lock == true
+p = Progress(10; safe_lock = false)
+@test p.safe_lock == false
+@test simple_sum(10) ≈ simple_sum(10; safe_lock = false)
 
 
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -80,3 +80,23 @@ prog.n = UInt128(20) # in Progress
 @test prog.n == 20
 prog.offset = Int8(5) # in ProgressCore
 @test prog.offset == 5
+
+# Test disable_lock option, initialization and
+# execution. 
+function simple_sum(n; disable_lock = false)
+    p = Progress(n; disable_lock)
+    s = 0.0
+    for i in 1:n
+        s += sin(i)
+        next!(p)
+    end
+    return s
+end
+p = Progress(10)
+@test p.disable_lock == false
+p = Progress(10; disable_lock = true)
+@test p.disable_lock == true
+@test simple_sum(10) ≈ simple_sum(10; disable_lock = true)
+
+
+

--- a/test/test.jl
+++ b/test/test.jl
@@ -386,6 +386,7 @@ finish!(prog)
 
 println("Testing fractional bars")
 for front in (['▏','▎','▍','▌','▋','▊', '▉'], ['▁' ,'▂' ,'▃' ,'▄' ,'▅' ,'▆', '▇'], ['░', '▒', '▓',])
+    local p
     p = Progress(100, dt=0.01, barglyphs=BarGlyphs('|','█',front,' ','|'), barlen=10)
     for i in 1:100
         next!(p)

--- a/test/test_threads.jl
+++ b/test/test_threads.jl
@@ -7,7 +7,6 @@
     threadsUsed = fill(false, threads)
     vals = ones(n*threads)
     p = Progress(n*threads)
-    p.threads_used = 1:threads # short-circuit the function `is_threading` because it is racy (#232)
     Threads.@threads for i = 1:(n*threads)
         threadsUsed[Threads.threadid()] = true
         vals[i] = 0
@@ -21,7 +20,6 @@
     println("Testing ProgressUnknown() with Threads.@threads across $threads threads")
     trigger = 100.0
     prog = ProgressUnknown(desc="Attempts at exceeding trigger:")
-    prog.threads_used = 1:threads
     vals = Float64[]
     threadsUsed = fill(false, threads)
     lk = ReentrantLock()
@@ -48,7 +46,6 @@
     println("Testing ProgressThresh() with Threads.@threads across $threads threads")
     thresh = 1.0
     prog = ProgressThresh(thresh; desc="Minimizing:")
-    prog.threads_used = 1:threads
     vals = fill(300.0, 1)
     threadsUsed = fill(false, threads)
     Threads.@threads for _ in 1:100000
@@ -76,7 +73,6 @@
         # threadsUsed = fill(false, threads)
         vals = ones(n*threads)
         p = Progress(n*threads)
-        p.threads_used = 1:threads
 
         for t in 1:threads
             tasks[t] = Threads.@spawn for i in 1:n


### PR DESCRIPTION
This is another possible fix for: https://github.com/timholy/ProgressMeter.jl/issues/317 and https://github.com/timholy/ProgressMeter.jl/issues/232

Here we remove the automatic identification of threading, and always use a lock by default. An option `safe_lock` is added, which is by default `true` and must be set to `false` to disable the lock.

Relative to the current stable version I don't see any measurable performance difference:

Current stable:

```julia
julia> function prog_perf(n)
           prog = Progress(n)
           x = 0.0
           for i in 1:n
               x += rand()
               next!(prog)
           end
           return x
       end
prog_perf (generic function with 1 method)

julia> @time prog_perf(10^7)
Progress: 100%|█████████████████████████████████████████████████████| Time: 0:00:05
  5.938973 seconds (122.22 M allocations: 1.889 GiB, 2.62% gc time, 28.52% compilation time)
4.999510125125184e6

julia> @time prog_perf(10^7)
Progress: 100%|█████████████████████████████████████████████████████| Time: 0:00:03
  3.953561 seconds (119.76 M allocations: 1.785 GiB, 2.68% gc time)
4.999360964692622e6

julia> @time prog_perf(10^7)
Progress: 100%|█████████████████████████████████████████████████████| Time: 0:00:04
  4.044011 seconds (119.74 M allocations: 1.784 GiB, 2.60% gc time)
5.0003511864208765e6
```

With this PR:

```julia
julia> function prog_perf(n; safe_lock=true)
           prog = Progress(n; safe_lock)
           x = 0.0
           for i in 1:n
               x += rand()
               next!(prog)
           end
           return x
       end
prog_perf (generic function with 1 method)

julia> @time prog_perf(10^7)
Progress: 100%|█████████████████████████████████████████████████████| Time: 0:00:04
  4.068567 seconds (119.76 M allocations: 1.785 GiB, 4.76% gc time)
5.002101485254395e6

julia> @time prog_perf(10^7)
Progress: 100%|█████████████████████████████████████████████████████| Time: 0:00:03
  3.992197 seconds (119.74 M allocations: 1.784 GiB, 3.91% gc time)
4.999887783558271e6

julia> @time prog_perf(10^7; safe_lock=false)
Progress: 100%|█████████████████████████████████████████████████████| Time: 0:00:03
  3.704703 seconds (119.74 M allocations: 1.784 GiB, 4.53% gc time)
4.998432809492471e6

julia> @time prog_perf(10^7; safe_lock=false)
Progress: 100%|█████████████████████████████████████████████████████| Time: 0:00:03
  3.749583 seconds (119.73 M allocations: 1.784 GiB, 4.10% gc time)
5.000024621577769e6
```

There is an apparent small but consistent advantage when `safe_lock=false`, which is expected. 