### PR TITLE
clarify that showvalues "name" can be a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ p = Progress(n)
 for iter in 1:10
     x *= 2
     sleep(0.5)
-    next!(p; showvalues = [(:iter,iter), (:x,x)])
+    next!(p; showvalues = [("iteration count",iter), ("x",x)])
 end
 ```
 
@@ -292,7 +292,7 @@ you can alternatively pass a zero-argument function as a callback to the `showva
 ```julia
 x,n = 1,10
 p = Progress(n)
-generate_showvalues(iter, x) = () -> [(:iter,iter), (:x,x)]
+generate_showvalues(iter, x) = () -> [("iteration count",iter), ("x",x)]
 for iter in 1:10
     x *= 2
     sleep(0.5)


### PR DESCRIPTION
In the `README.md` example, it used a symbol for the "name" in the `showvalue` argument.   It seems a lot clearer to use a string in the example — not only are strings less obscure than symbols, they are also more flexible and natural as labels.

Internally, the code [calls `string(name)`](https://github.com/timholy/ProgressMeter.jl/blob/45e21fb09fe2196a0ef75690bd96a4fa0d892f45/src/ProgressMeter.jl#L570), so it can be anything.

(Right now, `showvalues` is only documented in the README … would be nice to have this in a docstring somewhere.)