### PR TITLE
right-align labels in showvalues (not left-align)

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -567,7 +567,7 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        msg = "\n  " * rpad(string(name) * ": ", maxwidth+2+1) * string(value)
+        msg = "\n  " * lpad(string(name) * ": ", maxwidth+2+1) * string(value)
         max_len = (displaysize(p.output)::Tuple{Int,Int})[2]
         # I don't understand why the minus 1 is necessary here, but empircally
         # it is needed.


### PR DESCRIPTION
Before this PR, labels in `showvalues` are left-aligned, which looks weird:
```jl
julia> x,n = 1,10
(1, 10)

julia> p = Progress(n);

julia> for iter in 1:10
           x *= 2
           sleep(0.5)
           next!(p; showvalues = [("iteration count",iter), ("x",x)])
       end
Progress: 100%|█████████████████████████████████████████| Time: 0:00:05
  iteration count:  10
  x:                1024
```
afterwards, they are right-aligned:
```jl
julia> for iter in 1:10
           x *= 2
           sleep(0.5)
           next!(p; showvalues = [("iteration count",iter), ("x",x)])
       end
Progress: 100%|█████████████████████████████████████████| Time: 0:00:05
  iteration count:  10
                x: 1024
```
which seems more readable to me.