### PR TITLE
Fix printing of multiline values, and allow colors in showed values

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -580,7 +580,10 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        string_value = string(value, color=true)
+        string_value = let io = PipeBuffer()
+            show(IOContext(io, :color => true), value)
+            "\e[0m" * read(io, String)
+        end
         if countlines(IOBuffer(string_value)) > 1
             # Multiline objects should go on their own line so their
             # alignment doesn't get messed up

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -580,12 +580,12 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        string_value = if value isa AbstractString
+        string_value = "\e[0m" * if value isa AbstractString
             value
         else
             let io = PipeBuffer()
                 show(IOContext(io, :color => true), value)
-                "\e[0m" * read(io, String)
+                read(io, String)
             end
         end
         if countlines(IOBuffer(string_value)) > 1

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -580,7 +580,13 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        msg = "\n  " * lpad(string(name) * ": ", maxwidth+2+1) * string(value)
+        string_value = string(value, color=true)
+        if countlines(IOBuffer(string_value)) > 1
+            # Multiline objects should go on their own line so their
+            # alignment doesn't get messed up
+            string_value = "\n" * string_value
+        end
+        msg = "\n  " * lpad(string(name) * ": ", maxwidth+2+1) * string_value
         max_len = (displaysize(p.output)::Tuple{Int,Int})[2]
         # I don't understand why the minus 1 is necessary here, but empircally
         # it is needed.

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -580,9 +580,13 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        string_value = let io = PipeBuffer()
-            show(IOContext(io, :color => true), value)
-            "\e[0m" * read(io, String)
+        string_value = if value isa AbstractString
+            value
+        else
+            let io = PipeBuffer()
+                show(IOContext(io, :color => true), value)
+                "\e[0m" * read(io, String)
+            end
         end
         if countlines(IOBuffer(string_value)) > 1
             # Multiline objects should go on their own line so their

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -584,7 +584,7 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
         max_len = (displaysize(p.output)::Tuple{Int,Int})[2]
         # I don't understand why the minus 1 is necessary here, but empircally
         # it is needed.
-        msg_lines = ceil(Int, (length(msg)-1) / max_len)
+        msg_lines = countlines(IOBuffer(msg))-1
         if truncate && msg_lines >= 2
             # For multibyte characters, need to index with nextind.
             printover(p.output, msg[1:nextind(msg, 1, max_len-1)] * "…", color)


### PR DESCRIPTION
Closes #224. That solution only worked if the string was padded to the display width, but this solution should correctly be able to deal with multiline strings.

Here's a demo:
```julia
let n = 20
    xs = Float64[]
    p = Progress(n)
    for iter = 1:n
        append!(xs, rand())
        sleep(0.5)
        plt = lineplot(xs)
        ProgressMeter.next!(p; showvalues = [(:UnicodePlot, plt)])
    end
end
```
[Screencast_20250402_171908.webm](https://github.com/user-attachments/assets/ba31eae8-4742-4627-b68b-2dc6a1c1fb0e)
