### PR TITLE
Retry Fix printing of multiline values, and allow colors in showed values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,9 @@ julia = "1.6"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["Test", "Random", "Distributed", "InteractiveUtils"]
+test = ["Test", "Random", "Distributed", "InteractiveUtils", "StyledStrings", "UnicodePlots"]

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -580,13 +580,10 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        string_value = "\e[0m" * if value isa AbstractString
+        string_value = "\e[0m" * if value isa Union{String, SubString{String}}
             value
         else
-            let io = PipeBuffer()
-                show(IOContext(io, :color => true), value)
-                read(io, String)
-            end
+            repr("text/plain", value; context=IOContext(PipeBuffer(), :color => true))
         end
         if countlines(IOBuffer(string_value)) > 1
             # Multiline objects should go on their own line so their

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -580,7 +580,10 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        string_value = string(value, color=true)
+        string_value = let io = PipeBuffer()
+            show(IOContext(io, :color => true), value)
+            "\e[0m" * read(io, String)
+        end
         if countlines(IOBuffer(string_value)) > 1
             # Multiline objects should go on their own line so their
             # alignment doesn't get messed up

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -580,12 +580,12 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        string_value = if value isa AbstractString
+        string_value = "\e[0m" * if value isa AbstractString
             value
         else
             let io = PipeBuffer()
                 show(IOContext(io, :color => true), value)
-                "\e[0m" * read(io, String)
+                read(io, String)
             end
         end
         if countlines(IOBuffer(string_value)) > 1

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -580,7 +580,13 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        msg = "\n  " * lpad(string(name) * ": ", maxwidth+2+1) * string(value)
+        string_value = string(value, color=true)
+        if countlines(IOBuffer(string_value)) > 1
+            # Multiline objects should go on their own line so their
+            # alignment doesn't get messed up
+            string_value = "\n" * string_value
+        end
+        msg = "\n  " * lpad(string(name) * ": ", maxwidth+2+1) * string_value
         max_len = (displaysize(p.output)::Tuple{Int,Int})[2]
         # I don't understand why the minus 1 is necessary here, but empircally
         # it is needed.

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -580,9 +580,13 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
     p.numprintedvalues = 0
 
     for (name, value) in showvalues
-        string_value = let io = PipeBuffer()
-            show(IOContext(io, :color => true), value)
-            "\e[0m" * read(io, String)
+        string_value = if value isa AbstractString
+            value
+        else
+            let io = PipeBuffer()
+                show(IOContext(io, :color => true), value)
+                "\e[0m" * read(io, String)
+            end
         end
         if countlines(IOBuffer(string_value)) > 1
             # Multiline objects should go on their own line so their

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -584,7 +584,7 @@ function printvalues!(p::AbstractProgress, showvalues; color = :normal, truncate
         max_len = (displaysize(p.output)::Tuple{Int,Int})[2]
         # I don't understand why the minus 1 is necessary here, but empircally
         # it is needed.
-        msg_lines = ceil(Int, (length(msg)-1) / max_len)
+        msg_lines = countlines(IOBuffer(msg))-1
         if truncate && msg_lines >= 2
             # For multibyte characters, need to index with nextind.
             printover(p.output, msg[1:nextind(msg, 1, max_len-1)] * "…", color)

--- a/test/test_showvalues.jl
+++ b/test/test_showvalues.jl
@@ -1,3 +1,5 @@
+using StyledStrings, UnicodePlots
+
 for ijulia_behavior in [:warn, :clear, :append]
 
 ProgressMeter.ijulia_behavior(ijulia_behavior)
@@ -111,4 +113,19 @@ for i in 1:50
     sleep(0.1)
 end
 
-end # if
+println("Testing showvalues with UnicodePlot")
+prog = Progress(50; dt=1, desc="progress: ")
+for i in 1:50
+    update!(prog, i; showvalues = [("A plot", lineplot(rand(10)))])
+    sleep(0.1)
+end
+
+println("Testing showvalues with StyledStrings")
+prog = Progress(50; dt=1, desc="progress: ")
+for i in 1:50
+    str = AnnotatedString(" julia", [(2:6, :face, rand((:magenta, :red, :blue, :green)))])
+    update!(prog, i; showvalues = [("A plot", str)])
+    sleep(0.1)
+end
+    
+end # for


### PR DESCRIPTION
This is a continuation of #341 after it was reverted because it errored when encountering an `AnnotatedString`.

Seems to be working with `AnnotatedString`.
```julia
julia> let n = 20
           xs = Float64[]
           p = Progress(n)
           for iter = 1:n
               append!(xs, rand())
               sleep(0.5)
               plt = lineplot(xs)
               str = Base.AnnotatedString(" julia", [(2:6, :face, rand((:magenta, :red, :blue, :green)))])
               ProgressMeter.next!(p; showvalues = [(:UnicodePlot, plt), ("An annoted string", str2)])
           end
       end
```
[Screencast_20250405_002203.webm](https://github.com/user-attachments/assets/ff36211a-3219-474f-952e-543511bd77ea)

The downside is that styled strings will get a `"` wrapped around them as you can see in the video, so if anyone has any better suggestions for how to deal with this generically, I'd be open to input. cc @MilesCranmer