### PR TITLE
Fix duplicated bar

### DIFF
--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -173,7 +173,7 @@ end
 #...length of percentage and ETA string with days is 29 characters, speed string is always 14 extra characters
 function tty_width(desc, output, showspeed::Bool)
     full_width = displaysize(output)[2]
-    desc_width = length(desc)
+    desc_width = length(desc) + (endswith(desc, " ") ? 0 : 1)
     eta_width = 29
     speed_width = showspeed ? 14 : 0
     return max(0, full_width - desc_width - eta_width - speed_width)

--- a/src/ProgressMeter.jl
+++ b/src/ProgressMeter.jl
@@ -171,9 +171,11 @@ mutable struct ProgressUnknown <: AbstractProgress
 end
 
 #...length of percentage and ETA string with days is 29 characters, speed string is always 14 extra characters
+description_prefix(desc::AbstractString) = isempty(desc) || endswith(desc, " ") ? desc : desc * " "
+
 function tty_width(desc, output, showspeed::Bool)
     full_width = displaysize(output)[2]
-    desc_width = length(desc) + (endswith(desc, " ") ? 0 : 1)
+    desc_width = length(description_prefix(desc))
     eta_width = 29
     speed_width = showspeed ? 14 : 0
     return max(0, full_width - desc_width - eta_width - speed_width)
@@ -241,8 +243,8 @@ function _updateProgress!(p::Progress; showvalues = (),
             bar = barstring(barlen, percentage_complete, barglyphs=p.barglyphs)
             elapsed_time = t - p.tinit
             dur = durationstring(elapsed_time)
-            spacer = endswith(p.desc, " ") ? "" : " "
-            msg = @sprintf "%s%s%3u%%%s Time: %s" p.desc spacer percentage_rounded bar dur
+            prefix = description_prefix(p.desc)
+            msg = @sprintf "%s%3u%%%s Time: %s" prefix percentage_rounded bar dur
             if p.showspeed
                 sec_per_iter = elapsed_time / (p.counter - p.start)
                 msg = @sprintf "%s (%s)" msg speedstring(sec_per_iter)
@@ -278,8 +280,8 @@ function _updateProgress!(p::Progress; showvalues = (),
             else
                 eta = "N/A"
             end
-            spacer = endswith(p.desc, " ") ? "" : " "
-            msg = @sprintf "%s%s%3u%%%s  ETA: %s" p.desc spacer percentage_rounded bar eta
+            prefix = description_prefix(p.desc)
+            msg = @sprintf "%s%3u%%%s  ETA: %s" prefix percentage_rounded bar eta
             if p.showspeed
                 sec_per_iter = elapsed_time / (p.counter - p.start)
                 msg = @sprintf "%s (%s)" msg speedstring(sec_per_iter)

--- a/test/core.jl
+++ b/test/core.jl
@@ -13,6 +13,11 @@
 @test Progress(5, desc="Progress:", offset=Int16(5)).offset == 5
 @test ProgressThresh(0.2, desc="Progress:", offset=Int16(5)).offset == 5
 
+let output = IOContext(IOBuffer(), :displaysize => (24, 80))
+    @test ProgressMeter.tty_width("Building grid...", output, false) ==
+          ProgressMeter.tty_width("Building grid... ", output, false)
+end
+
 # test speed string formatting
 for ns in [1, 9, 10, 99, 100, 999, 1_000, 9_999, 10_000, 99_000, 100_000, 999_999, 1_000_000, 9_000_000, 10_000_000, 99_999_000, 1_234_567_890, 1_234_567_890 * 10, 1_234_567_890 * 100, 1_234_567_890 * 1_000, 1_234_567_890 * 10_000, 1_234_567_890 * 100_000, 1_234_567_890 * 1_000_000, 1_234_567_890 * 10_000_000]
     sec = ns / 1_000_000_000


### PR DESCRIPTION

This fixes a two-progress bar issue I was experiencing, because the "desc" field did not have a trailing space:

```
p = Progress(prod(n); desc="Building grid...")
``` 

(if the one adds a trailing space to "Bulding grid..." the issue is not manifested). 

```julia
#
# before the fix
#
leandro@m3g:~/Documents/ComplexMixturesExamples/scripts/example1% julia script3.jl 
  Activating project at `~/Documents/ComplexMixturesExamples/scripts/example1`
Building grid...   0%|                                                                     |  ETA: 1 days, 21:24:1
Building grid... 100%|█████████████████████████████████████████████████████████████████████| Time: 0:00:12
Grid written to ./grid.pdb
# 
# after the fix
#
leandro@m3g:~/Documents/ComplexMixturesExamples/scripts/example1% julia script3.jl 
  Activating project at `~/Documents/ComplexMixturesExamples/scripts/example1`
Precompiling PDBTools finished.
  3 dependencies successfully precompiled in 16 seconds. 43 already precompiled.
Precompiling ComplexMixtures finished.
  1 dependency successfully precompiled in 8 seconds. 67 already precompiled.
Building grid... 100%|████████████████████████████████████████████████████████████████████| Time: 0:00:12 21:04:04
Grid written to ./grid.pdb
```

The issue is also dependent on the terminal size. Maybe this fixes #352 